### PR TITLE
feat(transfer): Add Mesh SDK client-side transaction building support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/src/programmable-tokens-frontend/.gitignore
+++ b/src/programmable-tokens-frontend/.gitignore
@@ -36,3 +36,14 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Environment files
+.env
+.env.local
+
+# Log files
+*.log
+frontend.log
+
+# IDE files
+.vscode/

--- a/src/programmable-tokens-offchain-java/.gitignore
+++ b/src/programmable-tokens-offchain-java/.gitignore
@@ -3,4 +3,13 @@
 .java-version
 build
 
+.env
 .env.*
+# Log files
+*.log
+backend.log
+backend-error.log
+backend-run.log
+
+# Build artifacts
+bin/


### PR DESCRIPTION
- Add TransactionBuilderToggle to TransferModal component
- Support both backend and frontend transaction building modes
- Integrate Mesh SDK via substandard handler factory pattern
- Fetch protocol blueprint, bootstrap params, and substandard data
- Provide fallback to backend API for compatibility
- Improve user experience with builder mode selection

Right Now dummy is used:
   ->Determine substandard from asset
  ->For now, default to "dummy" - most tokens use this
    TODO: Query backend registry to get actual substandardId
      const substandardId = "dummy";

   If you need to support multiple substandards, you could:
   1. Try building with "dummy" first
   2. If it fails, try "bafin" or other substandards
   3. Or query the backend registry API 

## Related Issue

Closes #13

This enables users to build transfer transactions entirely in the frontend using Mesh SDK, reducing dependency on backend API and demonstrating client-side transaction construction capabilities.