### PR TITLE
Minor cleanups

### DIFF
--- a/src/programmable-tokens-onchain-aiken/lib/assets.ak
+++ b/src/programmable-tokens-onchain-aiken/lib/assets.ak
@@ -1,4 +1,4 @@
-use aiken/builtin.{less_than_bytearray}
+use aiken/builtin.{less_than_bytearray, less_than_equals_bytearray}
 use aiken/collection/dict
 use cardano/assets.{PolicyId, Value}
 use cardano/transaction.{Output}
@@ -35,19 +35,19 @@ fn do_split_at(
 ) -> result {
   when self is {
     [] -> return(before, dict.empty, [])
-    [head, ..tail] -> {
-      let k = head.1st
+    [Pair(k, _) as head, ..tail] ->
       if less_than_bytearray(k, at) {
         // Skip while keys are smaller (strictly) than searched key
         do_split_at(tail, at, [head, ..before], return)
-      } else if k == at {
-        // Done searching, get the value and return the tail after
-        return(before, head.2nd, tail)
       } else {
-        // The head and tail are all after the key; no need to continue searching.
-        return(before, dict.empty, self)
+        if k == at {
+          // Done searching, get the value and return the tail after
+          return(before, head.2nd, tail)
+        } else {
+          // The head and tail are all after the key; no need to continue searching.
+          return(before, dict.empty, self)
+        }
       }
-    }
   }
 }
 
@@ -142,15 +142,15 @@ pub fn union(left: Assets, right: Assets) -> Assets {
 fn do_insert(self: Assets, k1: PolicyId, v1: Tokens) -> Assets {
   when self is {
     [] -> [Pair(k1, v1)]
-    [Pair(k2, v2), ..rest] ->
-      if less_than_bytearray(k1, k2) {
-        [Pair(k1, v1), ..self]
-      } else {
+    [Pair(k2, _) as head, ..rest] ->
+      if less_than_equals_bytearray(k1, k2) {
         if k1 == k2 {
-          [Pair(k1, tokens.union(v1, v2)), ..rest]
+          [Pair(k1, tokens.union(v1, head.2nd)), ..rest]
         } else {
-          [Pair(k2, v2), ..do_insert(rest, k1, v1)]
+          [Pair(k1, v1), ..self]
         }
+      } else {
+        [head, ..do_insert(rest, k1, v1)]
       }
   }
 }

--- a/src/programmable-tokens-onchain-aiken/lib/types.ak
+++ b/src/programmable-tokens-onchain-aiken/lib/types.ak
@@ -25,8 +25,6 @@ pub type ProgrammableLogicGlobalRedeemer {
     registry_node_idx: Int,
     /// Starting index in outputs where processed outputs begin
     outputs_start_idx: Int,
-    /// Length of ALL inputs in the transaction
-    length_inputs: Int,
   }
 }
 

--- a/src/programmable-tokens-onchain-aiken/validators/programmable_logic/benchmarks.ak
+++ b/src/programmable-tokens-onchain-aiken/validators/programmable_logic/benchmarks.ak
@@ -123,7 +123,7 @@ const fixture_baseline_3rd_party_1: Transaction = {
   }
 
 const fixture_redeemer_baseline_3rd_party_1: ProgrammableLogicGlobalRedeemer =
-  ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 2, length_inputs: 2 }
+  ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 2 }
 
 test baseline_3rd_party_1() {
   programmable_logic(
@@ -260,7 +260,7 @@ const fixture_baseline_3rd_party_2: Transaction = {
   }
 
 const fixture_redeemer_baseline_3rd_party_2: ProgrammableLogicGlobalRedeemer =
-  ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 2, length_inputs: 3 }
+  ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 2 }
 
 test baseline_3rd_party_2() {
   programmable_logic(
@@ -345,11 +345,7 @@ const fixture_baseline_3rd_party_3: Transaction = {
   }
 
 const fixture_redeemer_baseline_3rd_party_3: ProgrammableLogicGlobalRedeemer =
-  ThirdPartyAct {
-    registry_node_idx: 1,
-    outputs_start_idx: 0,
-    length_inputs: length_baseline_3rd_party_3,
-  }
+  ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
 test baseline_3rd_party_3() {
   programmable_logic(

--- a/src/programmable-tokens-onchain-aiken/validators/programmable_logic/third_party.ak
+++ b/src/programmable-tokens-onchain-aiken/validators/programmable_logic/third_party.ak
@@ -18,7 +18,6 @@ pub fn validate_3rd_party(
   prog_logic_cred: Credential,
   registry_node: Data,
   outputs_start_idx: Int,
-  length_inputs: Int,
 ) -> Bool {
   // Extract registry details from datum
   let
@@ -54,7 +53,6 @@ pub fn validate_3rd_party(
     prog_logic_cred,
     policy_id,
     self.inputs,
-    length_inputs,
     outputs,
     minted_or_burned,
     output_tokens,
@@ -98,111 +96,93 @@ fn check_seized_tokens(
   prog_logic_cred: Credential,
   policy_id: PolicyId,
   inputs: List<Input>,
-  length_inputs: Int,
   outputs: List<Output>,
   input_tokens: Tokens,
   output_tokens: Tokens,
 ) -> Bool {
-  // This is an optimisation where the transaction builder also provides the length of the input indexes. This
-  // allows to not have to repeatedly pattern match on the input indices list to grab the next one; and converts
-  // that check into a null check on an integer.
-  //
-  // This is safe because:
-  //
-  // - if a larger length than the real one is given:
-  //     we'll attempt to 'list.head' on an empty list and the whole validation blows up.
-  //
-  // - if a smaller length than the real one is given:
-  //     we do ensures that there are no unprocessed programmable input once we
-  //     reach 0 (which would indicate someone tried to bypass validations).
-  //
-  if length_inputs <= 0 {
-    // All inputs must have been consumed / checked
-    expect [] == inputs
+  when inputs is {
+    [] -> {
+      // Finish accumulating relevant tokens in remaining outputs. This ensure
+      // that tokens that have moved to new outputs that weren't paired with a
+      // seized input are still accounted for.
+      let total_output_tokens =
+        foldl(
+          outputs,
+          output_tokens,
+          fn(output, acc) {
+            // Ensure to only count programmable outputs, to not allow tokens to escape.
+            if output.address.payment_credential == prog_logic_cred {
+              tokens.union(
+                // We can safely restrict to the given policy id, to prevent arbitrarily large values
+                // from being too costly to merge. We check inclusion in the end, from tokens that have
+                // also been filtered by policy id. So other tokens are irrelevant.
+                //
+                // If anything, it only makes the inclusion stronger by restricting the superset further.
+                output.value |> value.tokens(policy_id),
+                acc,
+              )
+            } else {
+              acc
+            }
+          },
+        )
 
-    // Finish accumulating relevant tokens in remaining outputs. This ensure
-    // that tokens that have moved to new outputs that weren't paired with a
-    // seized input are still accounted for.
-    let total_output_tokens =
-      foldl(
-        outputs,
-        output_tokens,
-        fn(output, acc) {
-          // Ensure to only count programmable outputs, to not allow tokens to escape.
-          if output.address.payment_credential == prog_logic_cred {
-            tokens.union(
-              // We can safely restrict to the given policy id, to prevent arbitrarily large values
-              // from being too costly to merge. We check inclusion in the end, from tokens that have
-              // also been filtered by policy id. So other tokens are irrelevant.
-              //
-              // If anything, it only makes the inclusion stronger by restricting the superset further.
-              output.value |> value.tokens(policy_id),
-              acc,
-            )
-          } else {
-            acc
-          }
-        },
-      )
-
-    // All the inputs tokens (seized or not) must still be sent to the prog
-    // logic validator. This is checked by ensuring all collected tokens are
-    // contained within all programmable outputs, while allowing those outputs
-    // to contain other things.
-    tokens.contains(
-      dict.to_pairs(total_output_tokens),
-      dict.to_pairs(input_tokens),
-    )?
-  } else {
-    let Input { output: input, .. } = list.head(inputs)
-
-    // Validate all inputs pointing at a programmable proof
-    if input.address.payment_credential == prog_logic_cred {
-      // Extract the paired output and ensures it preserves address and datum
-      let output = list.head(outputs)
-      expect output.address == input.address
-      expect output.datum == input.datum
-
-      // Extract seized tokens as the delta between outputs and inputs for the
-      // given policy, ensuring all else is equal.
-      let
-        input_tokens_before,
-        input_tokens_at,
-        input_tokens_after,
-      <- assets.split_at(input.value, policy_id)
-
-      let
-        output_tokens_before,
-        output_tokens_at,
-        output_tokens_after,
-      <- assets.split_at(output.value, policy_id)
-
-      // Seized tokens must change, but only them.
-      expect and {
-          (input_tokens_before == output_tokens_before)?,
-          (input_tokens_after == output_tokens_after)?,
-          (input_tokens_at != output_tokens_at)?,
-        }
-
-      check_seized_tokens(
-        prog_logic_cred,
-        policy_id,
-        list.tail(inputs),
-        length_inputs - 1,
-        list.tail(outputs),
-        tokens.union(input_tokens, input_tokens_at),
-        tokens.union(output_tokens_at, output_tokens),
-      )
-    } else {
-      check_seized_tokens(
-        prog_logic_cred,
-        policy_id,
-        list.tail(inputs),
-        length_inputs - 1,
-        outputs,
-        input_tokens,
-        output_tokens,
-      )
+      // All the inputs tokens (seized or not) must still be sent to the prog
+      // logic validator. This is checked by ensuring all collected tokens are
+      // contained within all programmable outputs, while allowing those outputs
+      // to contain other things.
+      tokens.contains(
+        dict.to_pairs(total_output_tokens),
+        dict.to_pairs(input_tokens),
+      )?
     }
+
+    [Input { output: input, .. }, ..tail_inputs] ->
+      // Validate all inputs pointing at a programmable proof
+      if input.address.payment_credential == prog_logic_cred {
+        // Extract the paired output and ensures it preserves address and datum
+        let output = list.head(outputs)
+        expect output.address == input.address
+        expect output.datum == input.datum
+
+        // Extract seized tokens as the delta between outputs and inputs for the
+        // given policy, ensuring all else is equal.
+        let
+          input_tokens_before,
+          input_tokens_at,
+          input_tokens_after,
+        <- assets.split_at(input.value, policy_id)
+
+        let
+          output_tokens_before,
+          output_tokens_at,
+          output_tokens_after,
+        <- assets.split_at(output.value, policy_id)
+
+        // Seized tokens must change, but only them.
+        expect and {
+            (input_tokens_before == output_tokens_before)?,
+            (input_tokens_after == output_tokens_after)?,
+            (input_tokens_at != output_tokens_at)?,
+          }
+
+        check_seized_tokens(
+          prog_logic_cred,
+          policy_id,
+          tail_inputs,
+          list.tail(outputs),
+          tokens.union(input_tokens, input_tokens_at),
+          tokens.union(output_tokens_at, output_tokens),
+        )
+      } else {
+        check_seized_tokens(
+          prog_logic_cred,
+          policy_id,
+          tail_inputs,
+          outputs,
+          input_tokens,
+          output_tokens,
+        )
+      }
   }
 }

--- a/src/programmable-tokens-onchain-aiken/validators/programmable_logic_global.ak
+++ b/src/programmable-tokens-onchain-aiken/validators/programmable_logic_global.ak
@@ -39,13 +39,12 @@ validator programmable_logic_global(params_policy: PolicyId) {
       TransferAct { proofs } ->
         validate_transfer(self, prog_logic_cred, get_registry_node, proofs)
 
-      ThirdPartyAct { registry_node_idx, outputs_start_idx, length_inputs } ->
+      ThirdPartyAct { registry_node_idx, outputs_start_idx } ->
         validate_3rd_party(
           self,
           prog_logic_cred,
           get_registry_node(registry_node_idx),
           outputs_start_idx,
-          length_inputs,
         )
     }
   }

--- a/src/programmable-tokens-onchain-aiken/validators/programmable_logic_global.test.ak
+++ b/src/programmable-tokens-onchain-aiken/validators/programmable_logic_global.test.ak
@@ -349,8 +349,7 @@ fn validate_third_party_with_outputs(
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct { registry_node_idx: 1, length_inputs: 2, outputs_start_idx }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -476,12 +475,7 @@ test third_party_act_seized_tokens_escape_prog_cred_must_fail() fail {
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 1,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -527,12 +521,7 @@ test third_party_act_seized_tokens_to_prog_cred_succeeds() {
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 1,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -580,12 +569,7 @@ test third_party_act_partial_seizure_succeeds() {
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 1,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -631,12 +615,7 @@ test third_party_act_delta_insufficient_remaining_fails() fail {
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 1,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1107,12 +1086,7 @@ test third_party_act_wipe_full_burn_succeeds() {
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 1,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1159,12 +1133,7 @@ test third_party_act_wipe_partial_burn_succeeds() {
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 1,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1214,12 +1183,7 @@ test third_party_act_wipe_seize_and_partial_burn() {
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 1,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1266,12 +1230,7 @@ test third_party_act_wipe_insufficient_after_burn_fails() fail {
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 1,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1311,12 +1270,7 @@ test third_party_act_unauthorized_burn_compensate_spend() fail {
       withdrawals: [Pair(fixture.credential_validator_logic_global, 0)],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 1,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1349,7 +1303,7 @@ test third_party_act_unproven_burn_compensate_spend() fail {
           "protocol params",
         ),
         third_party_registry_node_ref_input(
-          test_third_party_policy,
+          "not-the-expected-policy",
           test_third_party_cred,
         ),
       ],
@@ -1359,12 +1313,7 @@ test third_party_act_unproven_burn_compensate_spend() fail {
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 0,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1434,12 +1383,7 @@ test third_party_act_same_policy_mint_during_seizure_succeeds() {
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 1,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1486,12 +1430,7 @@ test third_party_act_same_policy_mint_insufficient_output_fails() fail {
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 1,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1542,12 +1481,7 @@ test third_party_act_unrelated_policy_mint_succeeds() {
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 1,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1597,12 +1531,7 @@ test third_party_act_wipe_burn_plus_unrelated_mint_succeeds() {
       ],
     }
 
-  let redeemer =
-    ThirdPartyAct {
-      registry_node_idx: 1,
-      outputs_start_idx: 0,
-      length_inputs: 1,
-    }
+  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,


### PR DESCRIPTION
- :round_pushpin: **Minor optimisation: slightly more laziness when merging tokens.**
  
- :round_pushpin: **Remove length from 3rd party redeemer**
    Not actually needed for anything, it makes the redeemer more complicated than it needs to be, makes the code 2-3% worse and make the code ~60 bytes larger. So it's a triple win, albeit not *super important*.

## Before

Script size: 2626 bytes

```
    ┍━ programmable_logic/benchmarks ━━━━━━━━━━━━━━━━━━━━━━━━━
    │ PASS [mem: 195.39 K, cpu:  76.39 M] baseline_3rd_party_1
    │ PASS [mem: 315.31 K, cpu: 121.15 M] baseline_3rd_party_2
    │ PASS [mem:   9.32 M, cpu:   3.89 B] baseline_3rd_party_3
    │ PASS [mem: 205.89 K, cpu:  77.34 M] plutarch_baseline_transfer
    │ PASS [mem: 339.87 K, cpu: 122.41 M] plutarch_baseline_transfer_2
    │ PASS [mem: 311.79 K, cpu: 111.99 M] plutarch_baseline_transfer_3
    ┕━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6 tests | 6 passed | 0 failed
```

Projected maximums:

dimension | max 
--- | --- 
tokens | 2020
inputs | 341
policies | 232 
outputs | 396 


## After

Script size: 2560 bytes

```
    ┍━ programmable_logic/benchmarks ━━━━━━━━━━━━━━━━━━━━━━━━━
    │ PASS [mem: 190.24 K, cpu:  74.11 M] baseline_3rd_party_1
    │ PASS [mem: 309.69 K, cpu: 118.70 M] baseline_3rd_party_2
    │ PASS [mem:   9.25 M, cpu:   3.87 B] baseline_3rd_party_3
    │ PASS [mem: 205.69 K, cpu:  77.31 M] plutarch_baseline_transfer
    │ PASS [mem: 334.58 K, cpu: 120.84 M] plutarch_baseline_transfer_2
    │ PASS [mem: 311.79 K, cpu: 111.99 M] plutarch_baseline_transfer_3
    ┕━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6 tests | 6 passed | 0 failed
```

Projected maximums:

dimension | max 
--- | --- 
tokens | 1973
inputs | 342 
policies | 233 
outputs | 398 

