### PR TITLE
feat: added in place update for registry node fields

### DIFF
--- a/aiken.lock
+++ b/aiken.lock
@@ -24,4 +24,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/fuzz@main" = [{ secs_since_epoch = 1781016231, nanos_since_epoch = 703675000 }, "9843473958e51725a9274b487d2d4aac0395ec1a2e30f090724fa737226bc127"]
+"aiken-lang/fuzz@main" = [{ secs_since_epoch = 1781179030, nanos_since_epoch = 709347000 }, "9843473958e51725a9274b487d2d4aac0395ec1a2e30f090724fa737226bc127"]

--- a/aiken.lock
+++ b/aiken.lock
@@ -24,4 +24,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/fuzz@main" = [{ secs_since_epoch = 1781179030, nanos_since_epoch = 709347000 }, "9843473958e51725a9274b487d2d4aac0395ec1a2e30f090724fa737226bc127"]
+"aiken-lang/fuzz@main" = [{ secs_since_epoch = 1781182640, nanos_since_epoch = 452856000 }, "9843473958e51725a9274b487d2d4aac0395ec1a2e30f090724fa737226bc127"]

--- a/lib/linked_list.ak
+++ b/lib/linked_list.ak
@@ -169,3 +169,25 @@ pub fn validate_mint(mint: Value, policy_id: PolicyId) -> AssetName {
     |> dict.to_pairs()
   asset_name
 }
+
+// True iff `new` equals `old` except possibly the mutable fields: 
+// transfer_logic_script, third_party_transfer_logic_script, and global_state_cs.
+// All other fields must still be well-formed. The record freezes key, next, and minting_logic_script
+pub fn is_field_updated_registry_node(
+  new: RegistryNode,
+  old: RegistryNode,
+) -> Bool {
+  and {
+    new == RegistryNode {
+      ..old,
+      transfer_logic_script: new.transfer_logic_script,
+      third_party_transfer_logic_script: new.third_party_transfer_logic_script,
+      global_state_cs: new.global_state_cs,
+    },
+    is_28_byte_credential(new.transfer_logic_script)?,
+    is_28_byte_credential(new.third_party_transfer_logic_script)?,
+    (bytearray.length(new.global_state_cs) == 0 || is_28_bytes(
+      new.global_state_cs,
+    ))?,
+  }
+}

--- a/lib/linked_list.ak
+++ b/lib/linked_list.ak
@@ -179,7 +179,9 @@ pub fn is_field_updated_registry_node(
 ) -> Bool {
   and {
     new == RegistryNode {
-      ..old,
+      key: old.key,
+      next: old.next,
+      minting_logic_script: old.minting_logic_script,
       transfer_logic_script: new.transfer_logic_script,
       third_party_transfer_logic_script: new.third_party_transfer_logic_script,
       global_state_cs: new.global_state_cs,

--- a/lib/linked_list.test.ak
+++ b/lib/linked_list.test.ak
@@ -1,6 +1,9 @@
 // Unit tests for linked list validation logic
 use cardano/address.{Script}
-use linked_list.{is_inserted_directory_node, is_updated_directory_node}
+use linked_list.{
+  is_field_updated_registry_node, is_inserted_directory_node,
+  is_updated_directory_node,
+}
 use registry_node.{RegistryNode}
 use utils.{bytearray_lt}
 
@@ -204,4 +207,67 @@ test is_updated_directory_node_rejects_global_state_swap() fail {
 
   // ^^^ TAMPERED — original was #""
   is_updated_directory_node(tampered_node, original, #"bb")
+}
+
+test is_field_updated_registry_node_rejects_registry_nodes_differ() fail {
+  let original = RegistryNode {
+    key: #"aa",
+    next: #"cc",
+    transfer_logic_script: Script(
+      #"11111111111111111111111111111111111111111111111111111111",
+    ),
+    third_party_transfer_logic_script: Script(
+      #"11111111111111111111111111111111111111111111111111111111",
+    ),
+    minting_logic_script: Script(
+      #"11111111111111111111111111111111111111111111111111111111",
+    ),
+    global_state_cs: #"",
+  }
+  let new = RegistryNode {
+    key: #"ab",
+    // changing an immutable field
+    next: #"cc",
+    transfer_logic_script: Script(
+      #"11111111111111111111111111111111111111111111111111111111",
+    ),
+    third_party_transfer_logic_script: Script(
+      #"11111111111111111111111111111111111111111111111111111111",
+    ),
+    minting_logic_script: Script(
+      #"11111111111111111111111111111111111111111111111111111111",
+    ),
+    global_state_cs: #"",
+  }
+
+  is_field_updated_registry_node(new, original)
+}
+
+test is_field_updated_registry_node_update_true() {
+  let original = RegistryNode {
+    key: #"aa",
+    next: #"cc",
+    transfer_logic_script: Script(
+      #"11111111111111111111111111111111111111111111111111111111",
+    ),
+    third_party_transfer_logic_script: Script(
+      #"22222222222222222222222222222222222222222222222222222222",
+    ),
+    minting_logic_script: Script(#"33"),
+    global_state_cs: #"",
+  }
+  let new = RegistryNode {
+    key: #"aa",
+    next: #"cc",
+    transfer_logic_script: Script(
+      #"ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    ),
+    third_party_transfer_logic_script: Script(
+      #"ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    ),
+    minting_logic_script: Script(#"33"),
+    global_state_cs: #"ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  }
+
+  is_field_updated_registry_node(new, original)
 }

--- a/validators/registry_spend.ak
+++ b/validators/registry_spend.ak
@@ -68,7 +68,7 @@ validator registry_spend(protocol_params_cs: PolicyId) {
         when old_node.minting_logic_script is {
           Script(_) ->
             pairs.has_key(self.withdrawals, old_node.minting_logic_script)
-          VerificationKey(pkh) -> list.has(self.extra_signatories, pkh)
+          VerificationKey(_) -> False
         }
       }
     }

--- a/validators/registry_spend.ak
+++ b/validators/registry_spend.ak
@@ -10,7 +10,7 @@ use cardano/address.{Script, VerificationKey}
 // the registry structure is being properly maintained.
 
 use cardano/assets.{PolicyId}
-use cardano/transaction.{Transaction}
+use cardano/transaction.{OutputReference, Transaction, find_input}
 use linked_list.{is_field_updated_registry_node, validate_directory_node_output}
 use programmable_logic/params.{ProgrammableLogicGlobalParams}
 use registry_node.{RegistryNode}
@@ -18,9 +18,9 @@ use utils.{expect_inline_datum, has_currency_symbol}
 
 validator registry_spend(protocol_params_cs: PolicyId) {
   spend(
-    _datum: Option<Data>,
+    datum: Option<RegistryNode>,
     _redeemer: Data,
-    _own_ref: Data,
+    own_ref: OutputReference,
     self: Transaction,
   ) {
     trace @"Starting registry_spend validation"
@@ -50,11 +50,8 @@ validator registry_spend(protocol_params_cs: PolicyId) {
       }
       // No registry node NFTs being minted or burned means we are updating a node
       None -> {
-        let own_input = list.expect_find(
-          self.inputs,
-          fn(i) { has_currency_symbol(i.output.value, registry_node_cs) },
-        )
-        expect old_node: RegistryNode = expect_inline_datum(own_input.output)
+        expect Some(own_input) = find_input(self.inputs, own_ref)
+        expect Some(old_node) = datum
         expect [cont] = list.filter(
           self.outputs,
           fn(o) { has_currency_symbol(o.value, registry_node_cs) },
@@ -64,11 +61,13 @@ validator registry_spend(protocol_params_cs: PolicyId) {
           registry_node_cs,
           own_input.output.address,
         )
-        expect is_field_updated_registry_node(new_node, old_node)
-        when old_node.minting_logic_script is {
-          Script(_) ->
-            pairs.has_key(self.withdrawals, old_node.minting_logic_script)
-          VerificationKey(_) -> False
+        and {
+          is_field_updated_registry_node(new_node, old_node),
+          when old_node.minting_logic_script is {
+            Script(_) ->
+              pairs.has_key(self.withdrawals, old_node.minting_logic_script)
+            VerificationKey(_) -> False
+          },
         }
       }
     }

--- a/validators/registry_spend.ak
+++ b/validators/registry_spend.ak
@@ -1,5 +1,7 @@
 use aiken/collection/dict
 use aiken/collection/list
+use aiken/collection/pairs
+use cardano/address.{Script, VerificationKey}
 // Registry spending validator - allows spending registry node UTxOs
 // Migrated from SmartTokens.LinkedList.SpendDirectory (pmkDirectorySpending)
 //
@@ -9,7 +11,9 @@ use aiken/collection/list
 
 use cardano/assets.{PolicyId}
 use cardano/transaction.{Transaction}
+use linked_list.{is_field_updated_registry_node, validate_directory_node_output}
 use programmable_logic/params.{ProgrammableLogicGlobalParams}
+use registry_node.{RegistryNode}
 use utils.{expect_inline_datum, has_currency_symbol}
 
 validator registry_spend(protocol_params_cs: PolicyId) {
@@ -34,12 +38,40 @@ validator registry_spend(protocol_params_cs: PolicyId) {
 
     let registry_node_cs = params.registry_node_cs
 
-    // Check that registry node NFTs are being minted or burned in this transaction
-    // This ensures we're modifying the registry structure (inserting/removing nodes)
-    expect Some(minted_assets) = assets.to_dict(self.mint)
-      |> dict.get(registry_node_cs)
-    expect [Pair(_, amount)] = dict.to_pairs(minted_assets)
-    amount > 0
+    when
+      assets.to_dict(self.mint)
+        |> dict.get(registry_node_cs)
+    is {
+      // Check that registry node NFTs are being minted or burned in this transaction
+      // This ensures we're modifying the registry structure (inserting) and the minting validator is called
+      Some(minted_assets) -> {
+        expect [Pair(_, amount)] = dict.to_pairs(minted_assets)
+        amount > 0
+      }
+      // No registry node NFTs being minted or burned means we are updating a node
+      None -> {
+        let own_input = list.expect_find(
+          self.inputs,
+          fn(i) { has_currency_symbol(i.output.value, registry_node_cs) },
+        )
+        expect old_node: RegistryNode = expect_inline_datum(own_input.output)
+        expect [cont] = list.filter(
+          self.outputs,
+          fn(o) { has_currency_symbol(o.value, registry_node_cs) },
+        )
+        let new_node = validate_directory_node_output(
+          cont,
+          registry_node_cs,
+          own_input.output.address,
+        )
+        expect is_field_updated_registry_node(new_node, old_node)
+        when old_node.minting_logic_script is {
+          Script(_) ->
+            pairs.has_key(self.withdrawals, old_node.minting_logic_script)
+          VerificationKey(pkh) -> list.has(self.extra_signatories, pkh)
+        }
+      }
+    }
   }
 
   else(_) {

--- a/validators/registry_spend.test.ak
+++ b/validators/registry_spend.test.ak
@@ -103,9 +103,19 @@ fn call_validator(tx: Transaction) -> Bool {
     test_protocol_params_cs,
     None,
     as_data(Void),
-    as_data(Void),
+    placeholder_own_ref(),
     tx,
   )
+}
+
+/// A throwaway OutputReference for tests that hit the minting (Some) branch,
+/// which never resolves own_ref. Update-path tests should pass an own_ref that
+/// matches the spent node input instead.
+fn placeholder_own_ref() -> OutputReference {
+  OutputReference {
+    transaction_id: #"0000000000000000000000000000000000000000000000000000000000000000",
+    output_index: 0,
+  }
 }
 
 // ========================================================================
@@ -362,13 +372,19 @@ fn new_registry_node() -> RegistryNode {
   }
 }
 
+/// OutputReference of the registry node being spent. Shared so the value the
+/// validator receives as `own_ref` matches the input `find_input` must locate.
+fn test_node_own_ref() -> OutputReference {
+  OutputReference {
+    transaction_id: #"3333333333333333333333333333333333333333333333333333333333333333",
+    output_index: 0,
+  }
+}
+
 /// A registry-node UTxO carrying the node NFT (token name == key) + inline datum.
 fn registry_node_input(node: RegistryNode) -> Input {
   Input {
-    output_reference: OutputReference {
-      transaction_id: #"3333333333333333333333333333333333333333333333333333333333333333",
-      output_index: 0,
-    },
+    output_reference: test_node_own_ref(),
     output: Output {
       address: test_node_address(),
       value: min_ada |> assets.add(test_registry_node_cs, test_node_key, 1),
@@ -401,7 +417,13 @@ fn update_transaction() -> Transaction {
 
 // Happy path: creator updates the 3 mutable fields with proper authorisation.
 test registry_spend_update_node() {
-  call_validator(update_transaction())
+  registry_spend.registry_spend.spend(
+    test_protocol_params_cs,
+    Some(old_registry_node()),
+    as_data(Void),
+    test_node_own_ref(),
+    update_transaction(),
+  )
 }
 
 // Reject: minting_logic_script is NOT invoked (no withdrawal) → unauthorised.

--- a/validators/registry_spend.test.ak
+++ b/validators/registry_spend.test.ak
@@ -12,6 +12,7 @@ use cardano/transaction.{
   InlineDatum, Input, NoDatum, Output, OutputReference, Transaction,
 }
 use programmable_logic/params.{ProgrammableLogicGlobalParams}
+use registry_node.{RegistryNode}
 use registry_spend
 
 // ---------------------------------------------------------------------------
@@ -285,6 +286,191 @@ test fails_empty_mint() fail {
     ..transaction.placeholder,
     reference_inputs: [protocol_params_ref_input()],
     mint: assets.zero,
+  }
+  call_validator(tx)
+}
+
+// ===========================================================================
+// In-place node update path (None branch: no registry_node_cs minted)
+//
+// The creator updates the 3 mutable fields (transfer_logic_script,
+// third_party_transfer_logic_script, global_state_cs) of an existing node,
+// keeping key / next / minting_logic_script frozen. Authorisation is the
+// node's own minting_logic_script invoked via withdraw-0.
+// ===========================================================================
+
+const test_node_key: ByteArray =
+  #"11111111111111111111111111111111111111111111111111111111"
+
+const test_node_next: ByteArray =
+  #"ffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+
+const test_minting_logic_hash: ByteArray =
+  #"22222222222222222222222222222222222222222222222222222222"
+
+const test_transfer_old: ByteArray =
+  #"33333333333333333333333333333333333333333333333333333333"
+
+const test_transfer_new: ByteArray =
+  #"44444444444444444444444444444444444444444444444444444444"
+
+const test_third_party_old: ByteArray =
+  #"55555555555555555555555555555555555555555555555555555555"
+
+const test_third_party_new: ByteArray =
+  #"66666666666666666666666666666666666666666666666666666666"
+
+const test_global_new: ByteArray =
+  #"77777777777777777777777777777777777777777777777777777777"
+
+const test_node_addr_hash: ByteArray =
+  #"88888888888888888888888888888888888888888888888888888888"
+
+const test_attacker_addr_hash: ByteArray =
+  #"99999999999999999999999999999999999999999999999999999999"
+
+const test_other_minting_hash: ByteArray =
+  #"abababababababababababababababababababababababababababab"
+
+/// The registry-node address (payment = registry_spend script, stake = None).
+fn test_node_address() -> Address {
+  Address {
+    payment_credential: Script(test_node_addr_hash),
+    stake_credential: None,
+  }
+}
+
+/// The node before the update.
+fn old_registry_node() -> RegistryNode {
+  RegistryNode {
+    key: test_node_key,
+    next: test_node_next,
+    minting_logic_script: Script(test_minting_logic_hash),
+    transfer_logic_script: Script(test_transfer_old),
+    third_party_transfer_logic_script: Script(test_third_party_old),
+    global_state_cs: #"",
+  }
+}
+
+/// The node after the update — only the 3 mutable fields change.
+fn new_registry_node() -> RegistryNode {
+  RegistryNode {
+    ..old_registry_node(),
+    transfer_logic_script: Script(test_transfer_new),
+    third_party_transfer_logic_script: Script(test_third_party_new),
+    global_state_cs: test_global_new,
+  }
+}
+
+/// A registry-node UTxO carrying the node NFT (token name == key) + inline datum.
+fn registry_node_input(node: RegistryNode) -> Input {
+  Input {
+    output_reference: OutputReference {
+      transaction_id: #"3333333333333333333333333333333333333333333333333333333333333333",
+      output_index: 0,
+    },
+    output: Output {
+      address: test_node_address(),
+      value: min_ada |> assets.add(test_registry_node_cs, test_node_key, 1),
+      datum: InlineDatum(as_data(node)),
+      reference_script: None,
+    },
+  }
+}
+
+fn registry_node_output(node: RegistryNode) -> Output {
+  Output {
+    address: test_node_address(),
+    value: min_ada |> assets.add(test_registry_node_cs, test_node_key, 1),
+    datum: InlineDatum(as_data(node)),
+    reference_script: None,
+  }
+}
+
+/// A valid in-place update tx: no registry mint, single node in/out, mutable
+/// fields changed, minting_logic_script invoked via withdraw-0.
+fn update_transaction() -> Transaction {
+  Transaction {
+    ..transaction.placeholder,
+    reference_inputs: [protocol_params_ref_input()],
+    inputs: [registry_node_input(old_registry_node())],
+    outputs: [registry_node_output(new_registry_node())],
+    withdrawals: [Pair(Script(test_minting_logic_hash), 0)],
+  }
+}
+
+// Happy path: creator updates the 3 mutable fields with proper authorisation.
+test registry_spend_update_node() {
+  call_validator(update_transaction())
+}
+
+// Reject: minting_logic_script is NOT invoked (no withdrawal) → unauthorised.
+// pairs.has_key returns False → validator returns False.
+test fails_update_without_minting_logic_withdrawal() fail {
+  let tx = Transaction { ..update_transaction(), withdrawals: [] }
+  call_validator(tx)
+}
+
+// Reject: a different credential is invoked, not the node's minting_logic_script.
+test fails_update_wrong_withdrawal_credential() fail {
+  let tx = Transaction {
+    ..update_transaction(),
+    withdrawals: [Pair(Script(test_other_minting_hash), 0)],
+  }
+  call_validator(tx)
+}
+
+// Reject: tampering with an immutable field (minting_logic_script). key/next are
+// untouched so validate_directory_node_output passes, but the record-equality in
+// is_field_updated_registry_node fails.
+test fails_update_changes_minting_logic() fail {
+  let tampered = RegistryNode {
+    ..new_registry_node(),
+    minting_logic_script: Script(test_other_minting_hash),
+  }
+  let tx = Transaction {
+    ..update_transaction(),
+    outputs: [registry_node_output(tampered)],
+  }
+  call_validator(tx)
+}
+
+// Reject: relocating the node NFT to a different address (theft). The continuing
+// output's address must equal the spent input's address.
+test fails_update_relocates_nft() fail {
+  let relocated = Output {
+    ..registry_node_output(new_registry_node()),
+    address: Address {
+      payment_credential: VerificationKey(test_attacker_addr_hash),
+      stake_credential: None,
+    },
+  }
+  let tx = Transaction { ..update_transaction(), outputs: [relocated] }
+  call_validator(tx)
+}
+
+// Reject: two continuing node outputs (batching / double-satisfaction). The
+// single-output filter `expect [cont]` rejects more than one.
+test fails_update_two_node_outputs() fail {
+  let tx = Transaction {
+    ..update_transaction(),
+    outputs: [
+      registry_node_output(new_registry_node()),
+      registry_node_output(new_registry_node()),
+    ],
+  }
+  call_validator(tx)
+}
+
+// Reject: malformed mutable value — a non-28-byte transfer_logic_script.
+test fails_update_malformed_transfer_logic() fail {
+  let bad = RegistryNode {
+    ..new_registry_node(),
+    transfer_logic_script: Script(#"1234"),
+  }
+  let tx = Transaction {
+    ..update_transaction(),
+    outputs: [registry_node_output(bad)],
   }
   call_validator(tx)
 }


### PR DESCRIPTION
Implementing the path to update a registry node. By spending an utxo and creating a new one.
With this change it is possible to update:
- transfer_logic_script
- third_party_logic_script
- global_state_cs
And enforcing fixed: key, next and minting_logic_script 

Implementation of: https://github.com/cardano-foundation/cip113-programmable-tokens/issues/75