### PR TITLE
Harden in-place upgrade path: validate credential well-formedness in upgrade datum

### DIFF
--- a/validators/coordination_spend.ak
+++ b/validators/coordination_spend.ak
@@ -39,6 +39,7 @@
 use aiken/collection/list
 use cardano/assets
 use cardano/transaction.{InlineDatum, OutputReference, Transaction, find_input}
+use linked_list.{is_28_byte_credential}
 use pairs
 use programmable_logic/params.{ProgrammableLogicGlobalParams}
 
@@ -92,6 +93,18 @@ validator coordination_spend(_nonce: ByteArray) {
       // deliberately outside upgrade scope.
       (new_params.prog_logic_cred == old_params.prog_logic_cred)?,
       (new_params.registry_node_cs == old_params.registry_node_cs)?,
+      // Mutable authority credentials must be well-formed (28-byte hashes).
+      // We cannot verify a credential resolves to an executable script — that is
+      // out of reach on-chain — but a WRONG-LENGTH credential can never be
+      // satisfied (no withdrawal key can equal it), which permanently bricks the
+      // field it gates: `prog_logic_global_cred` is PLB's per-spend gate (bricks
+      // every token), `upgrade_logic_cred` gates all future upgrades (bricks the
+      // coordination UTxO itself), and `unfracking_cred` gates unfracking. The
+      // frozen anchors above are already well-formed by construction (equal to
+      // the mint-validated old datum), so only the mutable fields are checked.
+      is_28_byte_credential(new_params.unfracking_cred)?,
+      is_28_byte_credential(new_params.prog_logic_global_cred)?,
+      is_28_byte_credential(new_params.upgrade_logic_cred)?,
       // No reference script may be attached to the coordination UTxO.
       (cont.reference_script == None)?,
       // Authorisation (trampoline 2): the CURRENT datum's upgrade authority must

--- a/validators/coordination_spend.test.ak
+++ b/validators/coordination_spend.test.ak
@@ -17,6 +17,7 @@ use cardano/transaction.{
 use coordination_spend
 use programmable_logic/fixture
 use programmable_logic/params.{ProgrammableLogicGlobalParams}
+use registry_node.{empty_vkey}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -427,6 +428,69 @@ test coord_fails_reference_script_attached() fail {
           #"abababababababababababababababababababababababababababab00",
         ),
       },
+    ],
+  }
+  call(tx)
+}
+
+// ---------------------------------------------------------------------------
+// Credential well-formedness (unsatisfiable-credential brick)
+// ---------------------------------------------------------------------------
+//
+// The datum rail above only TYPE-casts the continuing params
+// (`expect new_params: ProgrammableLogicGlobalParams`). A `Credential` carries
+// no length obligation, so an upgrade can write an empty / malformed / never-
+// satisfiable credential into a MUTABLE authority field and the cast still
+// succeeds. The frozen-anchor check covers only `prog_logic_cred` and
+// `registry_node_cs`, so the mutable authority fields are unprotected.
+//
+// The two reproductions below are KNOWN-RED until a credential well-formedness
+// rail is added (e.g. reject non-28-byte credentials, as the registry path
+// already does via `is_28_byte_credential`). Their positive controls already
+// exist above — `coord_upgrade_succeeds` (a well-formed 28-byte
+// `prog_logic_global_cred` is accepted) and `coord_authority_handover_succeeds`
+// (a well-formed `upgrade_logic_cred` change is accepted) — so such a guard
+// would not over-reject legitimate upgrades.
+
+// KNOWN-RED: `prog_logic_global_cred` is PLB's spend gate, read on every token
+// spend. `empty_vkey` (VerificationKey("")) is the repo's own "unset" sentinel
+// and can never equal any withdrawal key, so `has_key_or_fail` can never match
+// — every programmable token is frozen forever. coordination_spend SHOULD
+// reject this upgrade; it currently ACCEPTS, so this `fail` test is red until
+// the guard lands.
+test coord_rejects_unsatisfiable_plg_cred() fail {
+  let tx = Transaction {
+    ..valid_upgrade_tx(),
+    outputs: [
+      continuing_output(
+        ProgrammableLogicGlobalParams {
+          ..fixture.protocol_params,
+          prog_logic_global_cred: empty_vkey,
+        },
+        coordination_value(),
+        coordination_address(),
+      ),
+    ],
+  }
+  call(tx)
+}
+
+// KNOWN-RED: `upgrade_logic_cred` is the authority gate for FUTURE upgrades.
+// Writing an unsatisfiable value here means no later upgrade can ever be
+// authorised — the coordination UTxO, and the whole wiring it governs, is
+// frozen. coordination_spend SHOULD reject this but currently ACCEPTS.
+test coord_rejects_unsatisfiable_upgrade_cred() fail {
+  let tx = Transaction {
+    ..valid_upgrade_tx(),
+    outputs: [
+      continuing_output(
+        ProgrammableLogicGlobalParams {
+          ..fixture.protocol_params,
+          upgrade_logic_cred: empty_vkey,
+        },
+        coordination_value(),
+        coordination_address(),
+      ),
     ],
   }
   call(tx)


### PR DESCRIPTION
## Summary

Hardening for the in-place upgrade path. The coordination-spend upgrade rail
validates the continuing params datum with a type/arity cast only
(`expect new_params: ProgrammableLogicGlobalParams = cont_datum`). A `Credential`
carries no length obligation, so an upgrade could write an empty or wrong-length
credential into a mutable authority field and the cast still succeeded. Only
`prog_logic_cred` and `registry_node_cs` were frozen; the mutable authority
credentials went unchecked.

An unsatisfiable credential can never equal any withdrawal key, so
`has_key_or_fail` can never match — permanently bricking the field it gates:

- `prog_logic_global_cred` — PLB's per-spend gate → **every token frozen**.
- `upgrade_logic_cred` — the authority for future upgrades → **coordination UTxO frozen**.
- `unfracking_cred` — the unfracking gate → unfracking disabled.

No adversary is required: reaching for the `empty_vkey` ("unset") idiom on the
wrong field is enough. These fields freeze at bootstrap, so the mistake is
permanent.

## Fix

Add a 28-byte well-formedness check (`is_28_byte_credential`, already used on the
registry path in `lib/linked_list.ak`) to the three mutable authority
credentials in `coordination_spend`.

**Scope of the check:** this validates the *shape/length* of the credential
only. It cannot verify that a credential resolves to a deployed, executable
script — that is out of reach on-chain — but it rejects the wrong-length
credentials that are unconditionally unsatisfiable, which is the class that
silently bricks the protocol. The frozen anchors are already well-formed by
construction (equal to the mint-validated old datum), so only the mutable fields
are checked.

## Tests

`validators/coordination_spend.test.ak`, new "Credential well-formedness" section:

- `coord_rejects_unsatisfiable_plg_cred` — upgrade sets `prog_logic_global_cred`
  to `empty_vkey`; now rejected (was accepted before this change).
- `coord_rejects_unsatisfiable_upgrade_cred` — same for `upgrade_logic_cred`.

Existing positive controls (`coord_upgrade_succeeds`,
`coord_authority_handover_succeeds`) confirm well-formed 28-byte upgrades are
still accepted. Full suite green (682/682).

## Note

Minor hardening; low urgency (upgrade authority is trusted). Opened against the
in-place upgradability branch and may accumulate a few more small upgrade-path
hardening fixes before it merges.
