### PR TITLE
Forbid datum hashes and reference scripts on programmable-token outputs

### DIFF
--- a/lib/assets.ak
+++ b/lib/assets.ak
@@ -2,7 +2,7 @@ use aiken/builtin.{less_than_bytearray, less_than_equals_bytearray}
 use aiken/collection/dict
 use cardano/address.{Credential, Inline}
 use cardano/assets.{AssetName, PolicyId, Value}
-use cardano/transaction.{Output}
+use cardano/transaction.{DatumHash, Output}
 use env
 use list
 use tokens.{Tokens}
@@ -194,10 +194,34 @@ pub fn collect_output_assets(
     fn(output, select, discard) {
       if output.address.payment_credential == prog_logic_cred {
         expect Some(Inline(..)) = output.address.stake_credential
+        expect is_seizable_output_shape(output)?
         select(output)
       } else {
         discard()
       }
     },
   )
+}
+
+/// A programmable-token (PLB) output must stay seizable by a third party.
+///
+///   * A datum HASH is forbidden: to spend a datum-hash UTxO the ledger
+///     requires the datum preimage in the transaction witness, so a holder
+///     could pin an output with a secret preimage and make it unspendable by
+///     anyone but themselves — a third-party seizure could never be
+///     constructed. Only `NoDatum` or an inline datum is allowed.
+///   * A reference script is forbidden: a seizure must reproduce the paired
+///     input's reference script byte-for-byte in the continuing output, so a
+///     large one would bloat the (unavoidable, per-UTxO-atomic) seizure
+///     transaction past `maxTxSize`. Programmable-token UTxOs have no
+///     legitimate need to carry a reference script.
+///
+/// Enforced at every PLB-output creation site (transfer, mint, unfracking
+/// destinations) so the property holds inductively for all PLB UTxOs.
+pub fn is_seizable_output_shape(output: Output) -> Bool {
+  let datum_is_not_hash = when output.datum is {
+    DatumHash(_) -> False
+    _ -> True
+  }
+  datum_is_not_hash && output.reference_script == None
 }

--- a/lib/output_shape.test.ak
+++ b/lib/output_shape.test.ak
@@ -1,0 +1,92 @@
+//// Tests for the PLB-output seizability guard (`is_seizable_output_shape`)
+//// and its enforcement at the transfer creation gate (`collect_output_assets`).
+////
+//// A programmable-token UTxO must stay seizable by a third party:
+////   * no datum HASH — spending a datum-hash UTxO requires the datum preimage
+////     in the tx witness (ledger phase-1), so a holder could pin one with a
+////     secret preimage and make it unspendable by anyone but themselves; a
+////     seizure could never be built;
+////   * no reference script — a seizure must reproduce the paired input's
+////     reference script byte-for-byte, so a large one bloats the mandatory
+////     (per-UTxO-atomic) seizure transaction past maxTxSize.
+
+use assets
+use cardano/address.{Address, Credential, Inline, Script}
+use cardano/assets.{ada_asset_name, ada_policy_id} as value
+use cardano/transaction.{Datum, DatumHash, InlineDatum, NoDatum, Output}
+
+const prog_cred: Credential =
+  Script(#"a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1")
+
+const datum_hash_32: ByteArray =
+  #"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef00"
+
+const ref_script_28: ByteArray =
+  #"b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2"
+
+/// A PLB output (payment credential = prog_cred, inline stake credential) with
+/// the given datum and reference script.
+fn plb_output(datum: Datum, reference_script: Option<ByteArray>) -> Output {
+  Output {
+    address: Address {
+      payment_credential: prog_cred,
+      stake_credential: Some(
+        Inline(
+          Script(#"c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3"),
+        ),
+      ),
+    },
+    value: value.zero |> value.add(ada_policy_id, ada_asset_name, 2_000_000),
+    datum,
+    reference_script,
+  }
+}
+
+// -------------------------------------------------------- predicate: accepts
+
+test seizable_accepts_no_datum() {
+  assets.is_seizable_output_shape(plb_output(NoDatum, None))
+}
+
+test seizable_accepts_inline_datum() {
+  assets.is_seizable_output_shape(plb_output(InlineDatum(as_data(0)), None))
+}
+
+// -------------------------------------------------------- predicate: rejects
+
+test seizable_rejects_datum_hash() {
+  !assets.is_seizable_output_shape(plb_output(DatumHash(datum_hash_32), None))
+}
+
+test seizable_rejects_reference_script() {
+  !assets.is_seizable_output_shape(plb_output(NoDatum, Some(ref_script_28)))
+}
+
+// ------------------------------------------- transfer gate: collect rejects
+
+// The transfer creation gate aborts on a datum-hash PLB output. (Comparing the
+// result forces the collect call to run — a discarded pure result would be
+// optimized away, and the abort with it.)
+test collect_output_assets_rejects_datum_hash() fail {
+  assets.collect_output_assets(
+    [plb_output(DatumHash(datum_hash_32), None)],
+    prog_cred,
+  ) == []
+}
+
+// ... and on a reference-script PLB output.
+test collect_output_assets_rejects_reference_script() fail {
+  assets.collect_output_assets(
+    [plb_output(NoDatum, Some(ref_script_28))],
+    prog_cred,
+  ) == []
+}
+
+// Control: inline-datum and no-datum PLB outputs pass the gate (ada-only, so
+// the collected token set is empty).
+test collect_output_assets_accepts_clean_outputs() {
+  assets.collect_output_assets(
+    [plb_output(NoDatum, None), plb_output(InlineDatum(as_data(1)), None)],
+    prog_cred,
+  ) == []
+}

--- a/validators/issuance_mint.ak
+++ b/validators/issuance_mint.ak
@@ -1,5 +1,6 @@
 use aiken/collection/dict
 use aiken/collection/list
+use assets as prog_assets
 // Programmable Token Issuance Minting Policy
 // This policy handles minting and burning of registered programmable tokens
 // Migrated from SmartTokens.Contracts.Issuance
@@ -150,7 +151,10 @@ fn no_escape(
     fn(output) {
       if output.address.payment_credential == programmable_logic_base {
         expect Some(Inline(_stake_cred)) = output.address.stake_credential
-        True
+        // A minted programmable-token UTxO must stay seizable: no datum hash
+        // (unspendable without the preimage), no reference script (bloats the
+        // mandatory seizure continuing-output).
+        prog_assets.is_seizable_output_shape(output)
       } else {
         dict.is_empty(assets.tokens(output.value, own_policy))
       }

--- a/validators/issuance_mint.test.ak
+++ b/validators/issuance_mint.test.ak
@@ -10,8 +10,8 @@
 use cardano/address.{Address, Credential, Inline, Script}
 use cardano/assets.{PolicyId, ada_asset_name, ada_policy_id, from_asset}
 use cardano/transaction.{
-  InlineDatum, Input, Mint, NoDatum, Output, OutputReference, Transaction,
-  Withdraw,
+  DatumHash, InlineDatum, Input, Mint, NoDatum, Output, OutputReference,
+  Transaction, Withdraw,
 }
 use issuance_mint
 use registry_node.{RegistryNode, empty_vkey}
@@ -193,6 +193,32 @@ fn call_validator(rdmr: MintingRegistryProof, tx: Transaction) -> Bool {
 
 test valid_mint_with_ref_input() {
   call_validator(valid_redeemer(), valid_mint_tx())
+}
+
+// A minted PLB output carrying a datum HASH is rejected: such a UTxO is
+// unspendable without the preimage, so it could never be seized.
+test mint_rejects_datum_hash_output() fail {
+  let bad = Output {
+    ..mint_output(100),
+    datum: DatumHash(
+      #"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef00",
+    ),
+  }
+  let tx = Transaction { ..valid_mint_tx(), outputs: [bad] }
+  call_validator(valid_redeemer(), tx)
+}
+
+// A minted PLB output carrying a reference script is rejected: it would bloat
+// the mandatory seizure continuing-output.
+test mint_rejects_reference_script_output() fail {
+  let bad = Output {
+    ..mint_output(100),
+    reference_script: Some(
+      #"b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2",
+    ),
+  }
+  let tx = Transaction { ..valid_mint_tx(), outputs: [bad] }
+  call_validator(valid_redeemer(), tx)
 }
 
 test valid_mint_with_output_index() {

--- a/validators/programmable_logic/unfracking.ak
+++ b/validators/programmable_logic/unfracking.ak
@@ -210,6 +210,9 @@ fn drop_accum_owner_tokens(
     )
 
     if output.address == owner_address {
+      // Destination outputs are freshly created PLB UTxOs; keep them seizable
+      // (no datum hash, no reference script).
+      expect assets.is_seizable_output_shape(output)?
       loop(tokens.union(acc, output.value |> value.tokens(policy_id)))
     } else {
       loop(acc)
@@ -241,6 +244,9 @@ fn validate_pairs_and_conservation(
         output_tokens,
         fn(output, acc) {
           if output.address == owner_address {
+            // Destination outputs are freshly created PLB UTxOs; keep them
+            // seizable (no datum hash, no reference script).
+            expect assets.is_seizable_output_shape(output)?
             tokens.union(output.value |> value.tokens(policy_id), acc)
           } else {
             acc

--- a/validators/programmable_logic/unfracking.test.ak
+++ b/validators/programmable_logic/unfracking.test.ak
@@ -23,7 +23,7 @@ use cardano/address.{Credential, VerificationKey}
 use cardano/assets.{
   AssetName, PolicyId, ada_asset_name, ada_policy_id, from_asset, merge,
 }
-use cardano/transaction.{InlineDatum, Input, Output, Transaction}
+use cardano/transaction.{DatumHash, InlineDatum, Input, Output, Transaction}
 use programmable_logic/fixture
 use programmable_logic/params.{ProgrammableLogicGlobalParams}
 use programmable_logic_base
@@ -205,6 +205,39 @@ test unfracking_multi_utxo_consolidation_succeeds() {
       fixture.some_output_with_programmable_tokens([(policy_b, "BAR", 100)]),
       fixture.some_output_with_programmable_tokens([(policy_b, "BAR", 50)]),
       fixture.some_output_with_programmable_tokens([(policy_a, "FOO", 150)]),
+    ],
+  }
+  run_unfracking(tx)
+}
+
+// A destination output (a freshly created PLB UTxO receiving the regrouped
+// acted tokens) carrying a datum HASH is rejected: it would be unspendable
+// without the preimage, so it could never be seized. One delta against the
+// consolidation happy path: the acted-policy destination is datum-hashed.
+test unfracking_rejects_datum_hash_destination() fail {
+  let input_2 = fixture.some_input_with_programmable_tokens(
+    [(policy_a, "FOO", 50), (policy_b, "BAR", 50)],
+    "unfracking input 2",
+  )
+  let destination_with_hash = Output {
+    ..fixture.some_output_with_programmable_tokens([(policy_a, "FOO", 150)]),
+    datum: DatumHash(
+      #"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef00",
+    ),
+  }
+  let tx = Transaction {
+    ..valid_unfracking_tx(),
+    inputs: [
+      fixture.some_input_with_programmable_tokens(
+        [(policy_a, "FOO", 100), (policy_b, "BAR", 100)],
+        "unfracking input",
+      ),
+      input_2,
+    ],
+    outputs: [
+      fixture.some_output_with_programmable_tokens([(policy_b, "BAR", 100)]),
+      fixture.some_output_with_programmable_tokens([(policy_b, "BAR", 50)]),
+      destination_with_hash,
     ],
   }
   run_unfracking(tx)


### PR DESCRIPTION
Closes the datum-hash and reference-script vectors of #106 (the two with no design tension). The inline-datum **size** bound (vector 3) and the tokens discussion are deliberately left for follow-up — see #106.

## Problem

Programmable-token (PLB) outputs must stay seizable by a third party, but nothing constrained their datum *kind* or reference script (`collect_output_assets` checked only payment credential + inline stake credential).

- **Datum hash** — the ledger requires the datum preimage in the transaction witness to spend a datum-hash UTxO (phase 1). A holder can create their PLB UTxO with `DatumHash(hash(secret))`, keep the secret, spend it themselves, and no third-party seizure can ever be constructed. Unconditional, ~free (a 32-byte hash), preemptive, and repeatable (rotate the secret on each self-spend).
- **Reference script** — a seizure must reproduce the paired input's reference script byte-for-byte in the continuing output, so a large one bloats the (per-UTxO-atomic) seizure transaction past `maxTxSize`.

Both let a holder keep *using* an asset while making it unseizable — defeating the compliance guarantee.

## Fix

Add `is_seizable_output_shape(output)` — rejects `DatumHash`, requires `reference_script == None` — and enforce it at every PLB-output **creation** site so the property holds inductively for all PLB UTxOs:

- `lib/assets.ak` `collect_output_assets` — the `TransferAct` output path.
- `validators/issuance_mint.ak` `no_escape` — the mint output path.
- `validators/programmable_logic/unfracking.ak` — the unfracking destination outputs (paired outputs already reproduce the input, so they are clean if inputs are).

Constraining at creation (rather than relaxing the seizure reproduction check) is deliberate: letting seizure drop/alter a datum would let any programmable-token admin tamper with a co-resident policy's datum in a multi-asset UTxO.

Only `NoDatum` or an inline datum, and no reference script, are permitted. No legitimate programmable-token use needs either.

## Tests

- Predicate unit tests (`lib/output_shape.test.ak`): accepts NoDatum / inline; rejects datum hash / reference script.
- Transfer-gate tests: `collect_output_assets` aborts on a datum-hash or reference-script output; accepts clean outputs.
- Negative tests on the mint path (`issuance_mint.test.ak`) and unfracking path (`unfracking.test.ak`).
- Each negative was verified to FAIL against the pre-fix code (guard neutralized → all five go red), then pass once restored.
- Full suite green (600/600). The suite passing before these tests confirms no legitimate flow used datum hashes or reference scripts on PLB outputs.

Not yet deployed, so this is enforced from genesis with no migration.
