### PR TITLE
Locate the params UTxO by redeemer index, not by scanning (#103)

### DIFF
--- a/aiken.lock
+++ b/aiken.lock
@@ -24,4 +24,4 @@ requirements = []
 source = "github"
 
 [etags]
-"aiken-lang/fuzz@main" = [{ secs_since_epoch = 1786709268, nanos_since_epoch = 522430000 }, "9843473958e51725a9274b487d2d4aac0395ec1a2e30f090724fa737226bc127"]
+"aiken-lang/fuzz@main" = [{ secs_since_epoch = 1787152729, nanos_since_epoch = 664893000 }, "9843473958e51725a9274b487d2d4aac0395ec1a2e30f090724fa737226bc127"]

--- a/documentation/02-ARCHITECTURE.md
+++ b/documentation/02-ARCHITECTURE.md
@@ -344,26 +344,37 @@ type ProgrammableLogicGlobalParams {
 
 **Global validator** (`ProgrammableLogicGlobalRedeemer`):
 
+Every variant carries `params_idx` — the index of the protocol-params NFT UTxO
+in `reference_inputs`. The validator addresses that reference input directly
+(`list.at`) and authenticates it by the one-shot params NFT, rather than
+scanning the reference-input set. The index is a position into the ledger's
+canonical `reference_inputs` ordering (see [Reference inputs and redeemer
+indices](./09-DEVELOPING-SUBSTANDARDS.md#reference-inputs-and-redeemer-indices)).
+
 ```aiken
 type ProgrammableLogicGlobalRedeemer {
   // Normal transfer: one proof per non-ADA policy in the inputs
-  TransferAct { proofs: List<RegistryProof> }
+  TransferAct { params_idx: Int, proofs: List<RegistryProof> }
   // Administrative action — forced transfer / seizure / freeze enforcement /
   // burn (see 03-CONTROL-SCOPE-AND-ADMIN-AUTHORITY.md). Exactly one policy per
   // transaction; acts on every PLB input holding the subject policy; paired
   // continuing outputs begin at outputs_start_idx.
   ThirdPartyAct {
+    params_idx: Int,        // The protocol-params NFT UTxO in reference inputs
     registry_node_idx: Int, // The subject policy's registry node (one policy per tx)
     outputs_start_idx: Int,
   }
   // Finding 17: Unfracking — a holder redistributes the programmable tokens they
   // already hold across their own PLB UTxOs, WITHOUT invoking any substandard
-  // transfer logic. Value-preserving, same-owner. No payload: the standalone
-  // `unfracking` withdraw-0 validator (its credential is the params datum's
-  // `unfracking_cred`) enforces the invariants; PLG only checks it is invoked.
-  UnfrackingAct
+  // transfer logic. Value-preserving, same-owner. The standalone `unfracking`
+  // withdraw-0 validator (its credential is the params datum's `unfracking_cred`)
+  // enforces the invariants; PLG only checks it is invoked.
+  UnfrackingAct { params_idx: Int }
 }
 ```
+
+The `programmable_logic_base` spend redeemer is the same `params_idx` as an
+`Int` (it too reads the params UTxO, once per spent input).
 
 **Registry proofs** (`RegistryProof`):
 

--- a/documentation/08-INTEGRATION-GUIDES.md
+++ b/documentation/08-INTEGRATION-GUIDES.md
@@ -118,6 +118,8 @@ The transaction must include reference inputs (not consumed, just read):
 - **Protocol parameters UTxO** — contains the `ProgrammableLogicGlobalParams` datum with the registry node currency symbol and programmable logic credential.
 - **Registry node UTxO** — the registry entry for the token being transferred, containing the transfer logic script credential.
 
+> **Reference-input indices are supplied in the redeemer.** Every validator that reads the protocol-params UTxO (`programmable_logic_base`, `programmable_logic_global`, `unfracking`) jumps straight to it by index — `params_idx` — instead of scanning the reference-input set, and authenticates it by the one-shot params NFT. A transaction references several scripts (each as a reference input), so the builder must compute the params UTxO's position **in the canonical reference-input ordering** (the ledger sorts `reference_inputs` by `OutputReference` = `(transaction_id, output_index)`; the on-chain index is a position into that sorted list, not into the order you added them). Set `params_idx` to that position in each redeemer; a wrong index fails the NFT check. The same discipline applies to `registry_node_idx` for the registry node.
+
 #### 4. Registry Proofs
 
 The global validator needs a proof for each non-ADA policy in the transaction inputs. For programmable tokens, this is a `TokenExists` proof pointing to the registry node index. For any non-programmable tokens in the same UTxO (including ADA), a `TokenDoesNotExist` covering-node proof is needed.
@@ -152,8 +154,14 @@ Withdrawals:
   - (programmable_logic_global, 0)
   - (transfer_logic_script, 0)
 
+Redeemer (for programmable_logic_base, per spent input):
+  <protocol-params ref input index>            // an Int
+
 Redeemer (for programmable_logic_global):
-  TransferAct { proofs: [TokenExists { node_idx: <registry ref input index> }] }
+  TransferAct {
+    params_idx: <protocol-params ref input index>,
+    proofs: [TokenExists { node_idx: <registry ref input index> }],
+  }
 
 Required Signatories:
   - sender's key (whichever key matches their credential in the stake slot)

--- a/documentation/09-DEVELOPING-SUBSTANDARDS.md
+++ b/documentation/09-DEVELOPING-SUBSTANDARDS.md
@@ -821,7 +821,9 @@ const registryIndex = sortedRefInputs.findIndex(
 );
 
 const registryProof = conStr0([integer(registryIndex)]);       // TokenExists { node_idx }
-const plgRedeemer = conStr0([list([registryProof])]);          // TransferAct { proofs }
+// TransferAct { params_idx, proofs } — params_idx is the protocol-params NFT
+// UTxO's position in the sorted reference inputs (see below).
+const plgRedeemer = conStr0([integer(paramsIndex), list([registryProof])]);
 const transferRedeemer = integer(200);                          // Your substandard's redeemer
 
 const txBuilder = new MeshTxBuilder({ fetcher: provider, submitter: provider, evaluator: provider });

--- a/documentation/cip113-api-changes-post-audit.md
+++ b/documentation/cip113-api-changes-post-audit.md
@@ -588,6 +588,9 @@ live in that standalone validator.
   logic must account for it separately.
 - Anyone decoding the PLG redeemer must handle the new third variant.
 
+> On `feat/upgradability-in-place`, every variant additionally carries a leading
+> `params_idx: Int` — see §16.
+
 ---
 
 ## 10. Third-party action — protected prefixes + anti-injection
@@ -736,6 +739,52 @@ Two re-audit fixes are prepared on separate branches (§12):
   candidate branches (input-aware and no-escape variants).
 
 This document will be updated when each lands in `main`.
+
+---
+
+## 16. Protocol-params reference-input index in redeemers (upgradability branch)
+
+> On `feat/upgradability-in-place`. **Breaking redeemer-surface change.**
+
+Every validator that reads the protocol-params UTxO now locates it by a
+**redeemer-supplied index** into `reference_inputs`, authenticated by the
+one-shot params NFT, instead of scanning the reference-input set.
+
+**Motivation.** A programmable-token transaction references several scripts,
+each as a reference input, so scanning for the params UTxO is O(position) — and,
+before this change, aborted outright on a token-less reference-script UTxO
+ordered ahead of it (the reference-input order is fixed by the ledger, not the
+builder). A direct index is O(1) per lookup; since `programmable_logic_base`
+runs once **per spent input**, the saving multiplies across a multi-input
+transaction. The one-shot params NFT still authenticates the target, so a wrong
+index simply fails — no security is delegated to the index.
+
+### Redeemer changes
+
+- **`programmable_logic_base.spend`** — the redeemer was ignored (`Data`); it is
+  now an `Int`, the params-NFT reference-input index.
+- **`ProgrammableLogicGlobalRedeemer`** — every variant gains a leading
+  `params_idx: Int`:
+  ```aiken
+  TransferAct { params_idx: Int, proofs: List<RegistryProof> }
+  ThirdPartyAct { params_idx: Int, registry_node_idx: Int, outputs_start_idx: Int }
+  UnfrackingAct { params_idx: Int }
+  ```
+- **`UnfrackingRedeemer`** (standalone `unfracking` validator) — gains a leading
+  `params_idx: Int`.
+
+### Off-chain impact
+
+- Builders must compute the params UTxO's position in the **canonical**
+  `reference_inputs` ordering (the ledger sorts `reference_inputs` by
+  `OutputReference` = `(transaction_id, output_index)`) and pass it as
+  `params_idx` in each PLG/unfracking redeemer, and as the `Int` redeemer of
+  **every** `programmable_logic_base` spend in the transaction.
+- A wrong index fails the params-NFT authentication `expect`, so the whole
+  transaction fails — there is no silent misbehaviour.
+- `issuance_mint`'s delegation check is unaffected: it still locates the
+  coordination UTxO by NFT membership with fail-safe semantics (no coordination
+  UTxO ⇒ local custody), so it takes no params index.
 
 ---
 

--- a/lib/types.ak
+++ b/lib/types.ak
@@ -14,14 +14,22 @@ pub type RegistryProof {
   TokenDoesNotExist { node_idx: Int }
 }
 
-/// Redeemer for the global programmable logic stake validator
+/// Redeemer for the global programmable logic stake validator.
+///
+/// Every variant carries `params_idx`: the index of the protocol-params NFT
+/// UTxO in `reference_inputs`. The validator jumps straight to that reference
+/// input (`list.at`) and authenticates it by the one-shot params NFT, instead
+/// of scanning every reference input to find it — a wrong index simply fails
+/// the NFT check. See `params.with_protocol_params_fields`.
 pub type ProgrammableLogicGlobalRedeemer {
   /// Transfer action with proofs for each token type
-  TransferAct { proofs: List<RegistryProof> }
+  TransferAct { params_idx: Int, proofs: List<RegistryProof> }
   /// Third party action for administrative / compliance operations —
   /// forced transfer, seizure, freeze enforcement, or burn. Supports multiple
   /// UTxOs of the subject policy in a single transaction.
   ThirdPartyAct {
+    /// Index of the protocol-params NFT UTxO in reference inputs
+    params_idx: Int,
     /// Index of the registry node in reference inputs
     registry_node_idx: Int,
     /// Starting index in outputs where processed outputs begin
@@ -32,14 +40,23 @@ pub type ProgrammableLogicGlobalRedeemer {
   /// multi-policy "fracked" UTxO apart so a freeze on one policy stops
   /// collateral-damaging unrelated policies in the same UTxO.
   ///
-  /// No payload here: under this redeemer PLG only requires that the
+  /// Only `params_idx` here: under this redeemer PLG requires that the
   /// standalone `unfracking` withdraw-0 validator (whose credential is
   /// the `unfracking_cred` field of the protocol-params datum) is
   /// invoked in the same transaction. The acted-on policy, the pairing
   /// hints, and every invariant live with that validator (see
   /// `UnfrackingRedeemer`), keeping the hot-path PLG reference script
   /// small; only unfracking transactions pay for the unfracking logic.
-  UnfrackingAct
+  UnfrackingAct { params_idx: Int }
+}
+
+/// The protocol-params reference-input index, common to every variant.
+pub fn params_idx_of(redeemer: ProgrammableLogicGlobalRedeemer) -> Int {
+  when redeemer is {
+    TransferAct { params_idx, .. } -> params_idx
+    ThirdPartyAct { params_idx, .. } -> params_idx
+    UnfrackingAct { params_idx } -> params_idx
+  }
 }
 
 /// Redeemer of the standalone `unfracking` withdraw-0 validator (v2).
@@ -47,6 +64,8 @@ pub type ProgrammableLogicGlobalRedeemer {
 /// is single-policy, names its registry node, and pairs every PLB input
 /// positionally with a continuing output starting at `outputs_start_idx`.
 pub type UnfrackingRedeemer {
+  /// Index of the protocol-params NFT UTxO in reference inputs
+  params_idx: Int,
   /// Index of the acted-on policy's registry node in reference inputs
   registry_node_idx: Int,
   /// Starting index in outputs where the paired continuing outputs begin

--- a/validators/issuance_mint.ak
+++ b/validators/issuance_mint.ak
@@ -280,7 +280,7 @@ fn plgl_scope_covers(
   own_registry_node_idx: Int,
 ) -> Bool {
   when plg_redeemer is {
-    TransferAct { proofs } -> {
+    TransferAct { proofs, .. } -> {
       let expected_proof = TokenExists(own_registry_node_idx)
       list.any(proofs, fn(proof: RegistryProof) { expected_proof == proof })
     }
@@ -290,6 +290,6 @@ fn plgl_scope_covers(
     // restructuring with NO mint — it never validates an issuance's custody, so
     // it cannot cover one. Deny delegation (Finding 04 precise delegation):
     // issuance_mint must validate the mint outputs itself, not trust unfracking.
-    UnfrackingAct -> False
+    UnfrackingAct { .. } -> False
   }
 }

--- a/validators/issuance_mint.test.ak
+++ b/validators/issuance_mint.test.ak
@@ -280,7 +280,9 @@ test valid_burn() {
       Pair(Mint(test_own_policy), as_data(rdmr)),
       Pair(
         Withdraw(test_plg_cred),
-        as_data(TransferAct { proofs: [TokenExists { node_idx: 0 }] }),
+        as_data(
+          TransferAct { params_idx: 0, proofs: [TokenExists { node_idx: 0 }] },
+        ),
       ),
     ],
   }
@@ -665,7 +667,9 @@ test multi_token_burn() {
       Pair(Mint(test_own_policy), as_data(rdmr)),
       Pair(
         Withdraw(test_plg_cred),
-        as_data(TransferAct { proofs: [TokenExists { node_idx: 0 }] }),
+        as_data(
+          TransferAct { params_idx: 0, proofs: [TokenExists { node_idx: 0 }] },
+        ),
       ),
     ],
   }
@@ -698,7 +702,9 @@ test multi_token_spend_and_mint_defers() {
       Pair(Mint(test_own_policy), as_data(rdmr)),
       Pair(
         Withdraw(test_plg_cred),
-        as_data(TransferAct { proofs: [TokenExists { node_idx: 0 }] }),
+        as_data(
+          TransferAct { params_idx: 0, proofs: [TokenExists { node_idx: 0 }] },
+        ),
       ),
     ],
   }
@@ -962,7 +968,9 @@ test case4_spend_and_mint_same_token_valid() {
       Pair(Mint(test_own_policy), as_data(rdmr)),
       Pair(
         Withdraw(test_plg_cred),
-        as_data(TransferAct { proofs: [TokenExists { node_idx: 0 }] }),
+        as_data(
+          TransferAct { params_idx: 0, proofs: [TokenExists { node_idx: 0 }] },
+        ),
       ),
     ],
   }
@@ -1026,7 +1034,9 @@ test case4_spend_and_mint_defers_to_plglobal() {
       Pair(Mint(test_own_policy), as_data(valid_redeemer())),
       Pair(
         Withdraw(test_plg_cred),
-        as_data(TransferAct { proofs: [TokenExists { node_idx: 0 }] }),
+        as_data(
+          TransferAct { params_idx: 0, proofs: [TokenExists { node_idx: 0 }] },
+        ),
       ),
     ],
   }
@@ -1089,7 +1099,9 @@ test delegation_uses_live_plg_cred_from_coordination_datum() {
       Pair(Mint(test_own_policy), as_data(valid_redeemer())),
       Pair(
         Withdraw(test_plg_cred),
-        as_data(TransferAct { proofs: [TokenExists { node_idx: 0 }] }),
+        as_data(
+          TransferAct { params_idx: 0, proofs: [TokenExists { node_idx: 0 }] },
+        ),
       ),
     ],
   }
@@ -1108,7 +1120,9 @@ test delegation_survives_in_place_plg_upgrade() {
       Pair(Mint(test_own_policy), as_data(valid_redeemer())),
       Pair(
         Withdraw(test_plg_cred_v2),
-        as_data(TransferAct { proofs: [TokenExists { node_idx: 0 }] }),
+        as_data(
+          TransferAct { params_idx: 0, proofs: [TokenExists { node_idx: 0 }] },
+        ),
       ),
     ],
   }
@@ -1142,7 +1156,9 @@ test launch_era_plg_cred_cannot_delegate_after_upgrade_fails() fail {
       Pair(Mint(test_own_policy), as_data(valid_redeemer())),
       Pair(
         Withdraw(test_plg_cred),
-        as_data(TransferAct { proofs: [TokenExists { node_idx: 0 }] }),
+        as_data(
+          TransferAct { params_idx: 0, proofs: [TokenExists { node_idx: 0 }] },
+        ),
       ),
     ],
   }
@@ -1163,7 +1179,9 @@ test stale_plg_cred_delegation_denied_falls_back_to_custody() {
       Pair(Mint(test_own_policy), as_data(valid_redeemer())),
       Pair(
         Withdraw(test_plg_cred),
-        as_data(TransferAct { proofs: [TokenExists { node_idx: 0 }] }),
+        as_data(
+          TransferAct { params_idx: 0, proofs: [TokenExists { node_idx: 0 }] },
+        ),
       ),
     ],
   }
@@ -1200,7 +1218,9 @@ test plg_delegation_impossible_without_coordination_ref_input_fails() fail {
       Pair(Mint(test_own_policy), as_data(valid_redeemer())),
       Pair(
         Withdraw(test_plg_cred),
-        as_data(TransferAct { proofs: [TokenExists { node_idx: 0 }] }),
+        as_data(
+          TransferAct { params_idx: 0, proofs: [TokenExists { node_idx: 0 }] },
+        ),
       ),
     ],
   }
@@ -1240,7 +1260,9 @@ test coordination_datum_without_params_nft_cannot_delegate_fails() fail {
       Pair(Mint(test_own_policy), as_data(rdmr)),
       Pair(
         Withdraw(test_plg_cred),
-        as_data(TransferAct { proofs: [TokenExists { node_idx: 1 }] }),
+        as_data(
+          TransferAct { params_idx: 0, proofs: [TokenExists { node_idx: 1 }] },
+        ),
       ),
     ],
   }
@@ -1276,7 +1298,9 @@ test delegation_locates_coordination_ahead_of_registry_node() {
       Pair(Mint(test_own_policy), as_data(rdmr)),
       Pair(
         Withdraw(test_plg_cred),
-        as_data(TransferAct { proofs: [TokenExists { node_idx: 1 }] }),
+        as_data(
+          TransferAct { params_idx: 0, proofs: [TokenExists { node_idx: 1 }] },
+        ),
       ),
     ],
   }

--- a/validators/issuance_mint_benchmarks.ak
+++ b/validators/issuance_mint_benchmarks.ak
@@ -205,7 +205,10 @@ fn sample_delegate_transferact(
     withdrawals: [Pair(test_ml_cred, 0), Pair(test_plg_cred, 0)],
     redeemers: [
       Pair(Mint(test_own_policy), as_data(rdmr)),
-      Pair(Withdraw(test_plg_cred), as_data(TransferAct { proofs })),
+      Pair(
+        Withdraw(test_plg_cred),
+        as_data(TransferAct { params_idx: 0, proofs }),
+      ),
     ],
   }
   fuzz.constant((tx, rdmr))

--- a/validators/programmable_logic/benchmarks.ak
+++ b/validators/programmable_logic/benchmarks.ak
@@ -25,7 +25,7 @@ fn programmable_logic(
     programmable_logic_base.programmable_logic_base.spend(
       fixture.policy_protocol_params,
       None,
-      Void,
+      0,
       Void,
       self,
     ),
@@ -123,7 +123,7 @@ const fixture_baseline_3rd_party_1: Transaction = {
   }
 
 const fixture_redeemer_baseline_3rd_party_1: ProgrammableLogicGlobalRedeemer =
-  ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 2 }
+  ThirdPartyAct { params_idx: 0, registry_node_idx: 1, outputs_start_idx: 2 }
 
 test baseline_3rd_party_1() {
   programmable_logic(
@@ -268,7 +268,7 @@ const fixture_baseline_3rd_party_2: Transaction = {
   }
 
 const fixture_redeemer_baseline_3rd_party_2: ProgrammableLogicGlobalRedeemer =
-  ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 2 }
+  ThirdPartyAct { params_idx: 0, registry_node_idx: 1, outputs_start_idx: 2 }
 
 test baseline_3rd_party_2() {
   programmable_logic(
@@ -344,7 +344,7 @@ const fixture_baseline_3rd_party_3: Transaction = {
   }
 
 const fixture_redeemer_baseline_3rd_party_3: ProgrammableLogicGlobalRedeemer =
-  ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  ThirdPartyAct { params_idx: 0, registry_node_idx: 1, outputs_start_idx: 0 }
 
 test baseline_3rd_party_3() {
   programmable_logic(
@@ -416,7 +416,7 @@ const fixture_plutarch_baseline_transfer: Transaction = {
 /// Corresponding redeemer with a single proof of a token in the registry,
 /// located at position #2 in reference inputs
 const fixture_redeemer_plutarch_baseline_transfer: ProgrammableLogicGlobalRedeemer =
-  TransferAct { proofs: [TokenExists { node_idx: 1 }] }
+  TransferAct { params_idx: 0, proofs: [TokenExists { node_idx: 1 }] }
 
 test plutarch_baseline_transfer() {
   programmable_logic(
@@ -524,6 +524,7 @@ const fixture_plutarch_baseline_transfer_2: Transaction = {
 /// located at position #2 in reference inputs
 const fixture_redeemer_plutarch_baseline_transfer_2: ProgrammableLogicGlobalRedeemer =
   TransferAct {
+    params_idx: 0,
     proofs: [
       TokenExists { node_idx: 2 },
       TokenExists { node_idx: 3 },
@@ -618,6 +619,7 @@ const fixture_plutarch_baseline_transfer_3: Transaction = {
 
 const fixture_redeemer_plutarch_baseline_transfer_3: ProgrammableLogicGlobalRedeemer =
   TransferAct {
+    params_idx: 0,
     proofs: [
       TokenDoesNotExist { node_idx: 1 },
       TokenExists { node_idx: 2 },

--- a/validators/programmable_logic/fixture.ak
+++ b/validators/programmable_logic/fixture.ak
@@ -368,7 +368,7 @@ pub fn some_transfer(
           [],
           fn(_, node_idx, proofs) { [TokenExists { node_idx }, ..proofs] },
         )
-      |> TransferAct,
+      |> fn(proofs) { TransferAct { params_idx: 0, proofs } },
   )
 }
 
@@ -445,8 +445,12 @@ pub fn some_unfracking(
       ],
       withdrawals: withdrawals_unfracking,
     },
-    UnfrackingAct,
-    UnfrackingRedeemer { registry_node_idx: 1, outputs_start_idx: 0 },
+    UnfrackingAct { params_idx: 0 },
+    UnfrackingRedeemer {
+      params_idx: 0,
+      registry_node_idx: 1,
+      outputs_start_idx: 0,
+    },
   )
 }
 

--- a/validators/programmable_logic/params.ak
+++ b/validators/programmable_logic/params.ak
@@ -62,11 +62,15 @@ pub fn with_protocol_params_fields(
   params_idx: Int,
   return: fn(List<Data>) -> result,
 ) -> result {
-  expect Some(protocol_params_ref) = list.at(reference_inputs, params_idx)
+  let protocol_params_ref = list.expect_at(reference_inputs, params_idx)
 
-  // Authenticate: the addressed reference input must carry the params policy
-  // (the one-shot protocol-params NFT). A wrong index fails here rather than
-  // silently reading some other UTxO's datum.
+  // Authenticate: the addressed reference input must carry the params
+  // policy. Presence of the policy is sufficient — it is a one-shot NFT
+  // (protocol_params_mint mints exactly one `ProtocolParams` token), so any
+  // UTxO bearing it is the genuine params UTxO. A wrong index fails here
+  // rather than silently reading some other UTxO's datum. Kept as a bare
+  // policy-presence test (not the stricter name+quantity check) because this
+  // runs on the hot path — per PLG withdrawal and per PLB input.
   expect
     !dict.is_empty(
       value.tokens(protocol_params_ref.output.value, protocol_params_cs),

--- a/validators/programmable_logic/params.ak
+++ b/validators/programmable_logic/params.ak
@@ -1,5 +1,5 @@
 use aiken/builtin.{head_list, tail_list, unconstr_fields}
-use assets
+use aiken/collection/dict
 use cardano/address.{Credential}
 use cardano/assets.{PolicyId} as value
 use cardano/transaction.{InlineDatum, Input, Output}
@@ -103,7 +103,11 @@ fn get_protocol_params_ref(
   ref_inputs: List<Input>,
 ) -> Input {
   let head = head_list(ref_inputs)
-  if assets.peek_first(head.output) == protocol_params_cs {
+  // Direct policy lookup (dict.get, early-exit on the sorted value): total and
+  // order-independent. Skips reference inputs that do not carry the params
+  // policy — including token-less reference-script UTxOs, on which the old
+  // `peek_first` (head of the ada-less token list) aborted rather than skipped.
+  if !dict.is_empty(value.tokens(head.output.value, protocol_params_cs)) {
     head
   } else {
     get_protocol_params_ref(protocol_params_cs, tail_list(ref_inputs))

--- a/validators/programmable_logic/params.ak
+++ b/validators/programmable_logic/params.ak
@@ -1,8 +1,9 @@
 use aiken/builtin.{head_list, tail_list, unconstr_fields}
 use aiken/collection/dict
+use aiken/collection/list
 use cardano/address.{Credential}
 use cardano/assets.{PolicyId} as value
-use cardano/transaction.{InlineDatum, Input, Output}
+use cardano/transaction.{InlineDatum, Input}
 
 /// Protocol parameters NFT token name
 pub const protocol_params_token = "ProtocolParams"
@@ -36,11 +37,19 @@ pub type ProgrammableLogicGlobalParams {
   upgrade_logic_cred: Credential,
 }
 
-/// Locate the protocol-params NFT reference input and hand back the raw
-/// datum fields. Callers extract only the fields their branch needs via
-/// the `*_field` accessors below — cheaper than a full
-/// `expect _: ProgrammableLogicGlobalParams` deserialisation, which
-/// validates every field on every run.
+/// Authenticate the protocol-params NFT reference input by its
+/// caller-supplied index and hand back the raw datum fields. Callers
+/// extract only the fields their branch needs via the `*_field` accessors
+/// below — cheaper than a full `expect _: ProgrammableLogicGlobalParams`
+/// deserialisation, which validates every field on every run.
+///
+/// The redeemer carries `params_idx`, the index of the params UTxO in
+/// `reference_inputs`. Instead of scanning every reference input to find the
+/// params policy, we jump straight to `list.at(reference_inputs, params_idx)`
+/// and authenticate it by the one-shot params NFT: a wrong index simply fails
+/// the NFT check. This also makes Finding 082 structurally impossible — a
+/// token-less reference-script UTxO is never inspected unless it is the exact
+/// input the caller addressed.
 ///
 /// Skipping whole-datum validation here is safe for the same reason
 /// registry_node.ak skips it for RegistryNode: we only consume this
@@ -50,12 +59,18 @@ pub type ProgrammableLogicGlobalParams {
 pub fn with_protocol_params_fields(
   reference_inputs: List<Input>,
   protocol_params_cs: PolicyId,
+  params_idx: Int,
   return: fn(List<Data>) -> result,
 ) -> result {
-  let protocol_params_ref = get_protocol_params_ref(
-    protocol_params_cs,
-    reference_inputs,
-  )
+  expect Some(protocol_params_ref) = list.at(reference_inputs, params_idx)
+
+  // Authenticate: the addressed reference input must carry the params policy
+  // (the one-shot protocol-params NFT). A wrong index fails here rather than
+  // silently reading some other UTxO's datum.
+  expect
+    !dict.is_empty(
+      value.tokens(protocol_params_ref.output.value, protocol_params_cs),
+    )
 
   expect InlineDatum(inline_datum) = protocol_params_ref.output.datum
   return(unconstr_fields(inline_datum))
@@ -96,20 +111,4 @@ pub fn upgrade_logic_cred_field(fields: List<Data>) -> Credential {
     tail_list(tail_list(tail_list(tail_list(fields)))),
   )
   upgrade_logic_cred
-}
-
-fn get_protocol_params_ref(
-  protocol_params_cs: PolicyId,
-  ref_inputs: List<Input>,
-) -> Input {
-  let head = head_list(ref_inputs)
-  // Direct policy lookup (dict.get, early-exit on the sorted value): total and
-  // order-independent. Skips reference inputs that do not carry the params
-  // policy — including token-less reference-script UTxOs, on which the old
-  // `peek_first` (head of the ada-less token list) aborted rather than skipped.
-  if !dict.is_empty(value.tokens(head.output.value, protocol_params_cs)) {
-    head
-  } else {
-    get_protocol_params_ref(protocol_params_cs, tail_list(ref_inputs))
-  }
 }

--- a/validators/programmable_logic/params_cost.test.ak
+++ b/validators/programmable_logic/params_cost.test.ak
@@ -254,6 +254,7 @@ test cost_v5_split_first_two() {
   let fields <- with_protocol_params_fields(
     v5_ref_inputs(),
     fixture.policy_protocol_params,
+    0,
   )
   and {
     registry_node_cs_field(fields) == fixture.policy_tokens_registry,
@@ -266,6 +267,7 @@ test cost_v5_split_third_only() {
   let fields <- with_protocol_params_fields(
     v5_ref_inputs(),
     fixture.policy_protocol_params,
+    0,
   )
   unfracking_cred_field(fields) == fixture.credential_validator_unfracking
 }
@@ -276,6 +278,7 @@ test cost_v5_split_fourth_only() {
   let fields <- with_protocol_params_fields(
     v5_ref_inputs(),
     fixture.policy_protocol_params,
+    0,
   )
   prog_logic_global_cred_field(fields) == fixture.credential_validator_logic_global
 }
@@ -285,6 +288,7 @@ test cost_v5_split_all_four() {
   let fields <- with_protocol_params_fields(
     v5_ref_inputs(),
     fixture.policy_protocol_params,
+    0,
   )
   and {
     registry_node_cs_field(fields) == fixture.policy_tokens_registry,

--- a/validators/programmable_logic/params_ref_input_scan.test.ak
+++ b/validators/programmable_logic/params_ref_input_scan.test.ak
@@ -1,29 +1,24 @@
-//// Characterization tests for the protocol-params reference-input scan.
+//// Characterization tests for the protocol-params reference-input lookup.
 ////
-//// `get_protocol_params_ref` locates the protocol-params UTxO by walking
-//// `reference_inputs` and calling `assets.peek_first` on EACH one until a
-//// policy id matches `protocol_params_cs`. `peek_first` is
+//// `with_protocol_params_fields` no longer SCANS `reference_inputs` for the
+//// params NFT. The PLG/PLB redeemers now carry an explicit `params_idx`, and
+//// the lookup is a direct `list.at(reference_inputs, params_idx)` followed by
+//// an authentication `expect` that the indexed output actually holds the
+//// `protocol_params_cs` policy (the params NFT).
 ////
-////     list.head(list.tail(from_value(self.value))).1st
+//// Under the old scan model, an Ada-only reference-script UTxO (Ada +
+//// `reference_script`, no tokens — the canonical CIP-33 shape) ordered BEFORE
+//// the params NFT would be `peek_first`-probed and abort the script (Finding
+//// 082). With the index model that failure is structurally impossible: an
+//// input the caller does not point `params_idx` at is never inspected. A
+//// token-less reference input at index 0 is simply never touched when the
+//// params UTxO is addressed at its real index.
 ////
-//// which — as its own doc comment states — "fails loudly if the output holds
-//// no tokens (beyond Ada)": for an Ada-only value `from_value` yields a single
-//// entry, `list.tail` yields `[]`, and `list.head([])` aborts the script.
-////
-//// A reference-script UTxO is exactly such an output (Ada-only + a
-//// `reference_script`, no tokens) and is the canonical way a script is supplied
-//// to a transaction (CIP-33) — via `reference_inputs`, whose order in the
-//// script context is fixed by `(tx_id, output_index)`, not by the builder. So
-//// if such an input is ordered BEFORE the params NFT input, the scan calls
-//// `peek_first` on it and aborts.
-////
-//// The suite previously had NO test constructing a token-less reference input,
-//// so this shape was uncovered. Issue #103 replaced the `peek_first` head-read
-//// with a direct, total policy lookup (`value.tokens |> dict.is_empty`), so a
-//// token-less reference input is now SKIPPED rather than aborted on.
-//// `..._finds_params_despite_adaonly_refscript_first` pins that the params NFT
-//// is found even when such an input is ordered first; `..._ok_when_params_first`
-//// keeps the control (params NFT reached first).
+//// `..._finds_params_when_indexed_past_adaonly_refscript` pins that the params
+//// NFT is found at index 1 even though an Ada-only reference-script input sits
+//// at index 0 (that index-0 input is never inspected). `..._fails_index_points_
+//// at_adaonly_input` pins that pointing `params_idx` at the token-less input
+//// aborts on the NFT-authentication `expect`.
 
 use cardano/address
 use cardano/transaction.{Input, NoDatum, Output, OutputReference}
@@ -62,26 +57,28 @@ fn params_ref_input() -> Input {
 }
 
 // Finding 082 / issue #103 (FIXED): an Ada-only reference-script input ordered
-// before the params NFT is skipped, and the scan still finds the params NFT.
-// Previously `peek_first` aborted on that token-less value; the scan now uses a
-// direct, total policy lookup.
-test params_scan_finds_params_despite_adaonly_refscript_first() {
+// before the params NFT no longer aborts anything. The redeemer's `params_idx`
+// addresses the params UTxO directly (here index 1); the token-less input at
+// index 0 is never inspected, so the 082 abort is structurally impossible.
+test params_lookup_finds_params_when_indexed_past_adaonly_refscript() {
   let ref_inputs = [ada_only_reference_script_input(), params_ref_input()]
   let fields <- with_protocol_params_fields(
     ref_inputs,
     fixture.policy_protocol_params,
+    1,
   )
   registry_node_cs_field(fields) == fixture.policy_tokens_registry
 }
 
-// Control: the SAME two inputs with the params NFT reached first — the scan
-// matches on the first element and never calls `peek_first` on the Ada-only
-// input, so the lookup succeeds.
-test params_scan_ok_when_params_input_first() {
-  let ref_inputs = [params_ref_input(), ada_only_reference_script_input()]
+// Pointing `params_idx` at the Ada-only input (index 0) must abort: that output
+// does not hold the params policy, so the NFT-authentication `expect` inside
+// `with_protocol_params_fields` fails.
+test params_lookup_fails_index_points_at_adaonly_input() fail {
+  let ref_inputs = [ada_only_reference_script_input(), params_ref_input()]
   let fields <- with_protocol_params_fields(
     ref_inputs,
     fixture.policy_protocol_params,
+    0,
   )
   registry_node_cs_field(fields) == fixture.policy_tokens_registry
 }

--- a/validators/programmable_logic/params_ref_input_scan.test.ak
+++ b/validators/programmable_logic/params_ref_input_scan.test.ak
@@ -18,14 +18,12 @@
 //// `peek_first` on it and aborts.
 ////
 //// The suite previously had NO test constructing a token-less reference input,
-//// so this shape was uncovered. `..._aborts_..._first` LOCKS IN the current
-//// (abortive) behaviour; it is `fail`-annotated so it stays green today. When
-//// the scan is made total over token-less reference inputs (e.g. a
-//// `has_currency_symbol` membership scan, mirroring `registry_spend.ak`), this
-//// test must be flipped to a passing assertion. `..._ok_when_params_first`
-//// isolates the cause: the same two inputs succeed when the params NFT is
-//// reached first, so the divergence is purely `peek_first`'s partiality under
-//// reference-input ordering.
+//// so this shape was uncovered. Issue #103 replaced the `peek_first` head-read
+//// with a direct, total policy lookup (`value.tokens |> dict.is_empty`), so a
+//// token-less reference input is now SKIPPED rather than aborted on.
+//// `..._finds_params_despite_adaonly_refscript_first` pins that the params NFT
+//// is found even when such an input is ordered first; `..._ok_when_params_first`
+//// keeps the control (params NFT reached first).
 
 use cardano/address
 use cardano/transaction.{Input, NoDatum, Output, OutputReference}
@@ -63,11 +61,11 @@ fn params_ref_input() -> Input {
   )
 }
 
-// KNOWN BEHAVIOUR (Finding 082 / issue #103): an Ada-only reference-script input
-// ordered before the params NFT aborts the scan (`peek_first` on a token-less
-// value). `fail`-annotated so it is green today and documents the brick; FLIP
-// to a passing assertion when the scan is made total.
-test params_scan_aborts_on_adaonly_refscript_first() fail {
+// Finding 082 / issue #103 (FIXED): an Ada-only reference-script input ordered
+// before the params NFT is skipped, and the scan still finds the params NFT.
+// Previously `peek_first` aborted on that token-less value; the scan now uses a
+// direct, total policy lookup.
+test params_scan_finds_params_despite_adaonly_refscript_first() {
   let ref_inputs = [ada_only_reference_script_input(), params_ref_input()]
   let fields <- with_protocol_params_fields(
     ref_inputs,

--- a/validators/programmable_logic/unfracking.test.ak
+++ b/validators/programmable_logic/unfracking.test.ak
@@ -57,10 +57,14 @@ const second_vkey_pkh: ByteArray =
 const eve_vkey_pkh: ByteArray =
   #"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 
-const plg_redeemer = UnfrackingAct
+const plg_redeemer = UnfrackingAct { params_idx: 0 }
 
 const unfracking_redeemer =
-  UnfrackingRedeemer { registry_node_idx: 1, outputs_start_idx: 0 }
+  UnfrackingRedeemer {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
 // ----------------------------------------------------------------- fixtures
 
@@ -257,7 +261,11 @@ test unfracking_paired_outputs_skipped_succeeds() {
   }
   run_unfracking_with(
     tx,
-    UnfrackingRedeemer { registry_node_idx: 1, outputs_start_idx: 1 },
+    UnfrackingRedeemer {
+      params_idx: 0,
+      registry_node_idx: 1,
+      outputs_start_idx: 1,
+    },
   )
 }
 
@@ -349,7 +357,11 @@ test unfracking_preserves_unregistered_token_succeeds() {
 test unfracking_negative_outputs_start_idx_behaves_as_zero() {
   run_unfracking_with(
     valid_unfracking_tx(),
-    UnfrackingRedeemer { registry_node_idx: 1, outputs_start_idx: -1 },
+    UnfrackingRedeemer {
+      params_idx: 0,
+      registry_node_idx: 1,
+      outputs_start_idx: -1,
+    },
   )
 }
 
@@ -799,7 +811,7 @@ test unfracking_full_composition_succeeds() {
     programmable_logic_base.programmable_logic_base.spend(
       fixture.policy_protocol_params,
       None,
-      Void,
+      0,
       Void,
       tx,
     ),

--- a/validators/programmable_logic_base.ak
+++ b/validators/programmable_logic_base.ak
@@ -20,19 +20,21 @@ use programmable_logic/params
 validator programmable_logic_base(params_policy: PolicyId) {
   spend(
     _datum: Option<Data>,
-    _redeemer: Data,
+    params_idx: Int,
     _own_ref: Data,
     self: Transaction,
   ) {
     trace @"Starting programmable_logic_base validation"
 
-    // Locate the protocol-params NFT among the reference inputs and pull
-    // the live PLG credential out of its datum. The params UTxO is already
-    // a mandatory reference input on every programmable-token transaction
-    // (PLG reads it), so this adds no availability requirement.
+    // Locate the protocol-params NFT among the reference inputs (addressed by
+    // the redeemer's `params_idx`) and pull the live PLG credential out of its
+    // datum. The params UTxO is already a mandatory reference input on every
+    // programmable-token transaction (PLG reads it), so this adds no
+    // availability requirement.
     let fields <- params.with_protocol_params_fields(
       self.reference_inputs,
       params_policy,
+      params_idx,
     )
     let plg_cred = params.prog_logic_global_cred_field(fields)
 

--- a/validators/programmable_logic_base.test.ak
+++ b/validators/programmable_logic_base.test.ak
@@ -68,10 +68,16 @@ fn valid_plb_tx() -> Transaction {
 }
 
 fn call_validator(tx: Transaction) -> Bool {
+  call_validator_at(tx, 0)
+}
+
+/// `call_validator` with an explicit `params_idx` — for tests where the
+/// params UTxO is NOT the first reference input.
+fn call_validator_at(tx: Transaction, params_idx: Int) -> Bool {
   programmable_logic_base.programmable_logic_base.spend(
     fixture.policy_protocol_params,
     None,
-    Void,
+    params_idx,
     Void,
     tx,
   )
@@ -140,7 +146,8 @@ test plb_passes_when_params_ref_not_first() {
       params_ref_input(),
     ],
   }
-  call_validator(tx)
+  // params UTxO is the SECOND reference input here → params_idx = 1
+  call_validator_at(tx, 1)
 }
 
 // Fails when no reference input carries the params NFT policy

--- a/validators/programmable_logic_global.ak
+++ b/validators/programmable_logic_global.ak
@@ -16,6 +16,7 @@ use programmable_logic/transfer.{validate_transfer}
 use registry_node.{new_registry_node_getter}
 use types.{
   ProgrammableLogicGlobalRedeemer, ThirdPartyAct, TransferAct, UnfrackingAct,
+  params_idx_of,
 }
 
 validator programmable_logic_global(params_policy: PolicyId) {
@@ -32,6 +33,7 @@ validator programmable_logic_global(params_policy: PolicyId) {
     let fields <- with_protocol_params_fields(
       self.reference_inputs,
       params_policy,
+      params_idx_of(redeemer),
     )
 
     // Pre-construct a getter for registry nodes in reference inputs, to avoid
@@ -48,7 +50,7 @@ validator programmable_logic_global(params_policy: PolicyId) {
     )
 
     when redeemer is {
-      TransferAct { proofs } ->
+      TransferAct { proofs, .. } ->
         validate_transfer(
           self,
           prog_logic_cred_field(fields),
@@ -56,7 +58,7 @@ validator programmable_logic_global(params_policy: PolicyId) {
           proofs,
         )
 
-      ThirdPartyAct { registry_node_idx, outputs_start_idx } ->
+      ThirdPartyAct { registry_node_idx, outputs_start_idx, .. } ->
         validate_3rd_party(
           self,
           prog_logic_cred_field(fields),
@@ -71,7 +73,7 @@ validator programmable_logic_global(params_policy: PolicyId) {
       // validator, whose credential lives in the protocol-params datum
       // (field 2 — read only by this branch); PLG only gates on its
       // presence so the hot-path reference script stays small.
-      UnfrackingAct ->
+      UnfrackingAct { .. } ->
         pairs.has_key_or_fail(self.withdrawals, unfracking_cred_field(fields))
     }
   }

--- a/validators/programmable_logic_global.test.ak
+++ b/validators/programmable_logic_global.test.ak
@@ -47,10 +47,10 @@ test transfer_act_redeemer() {
   let proof1 = TokenExists { node_idx: 0 }
   let proof2 = TokenDoesNotExist { node_idx: 1 }
 
-  let redeemer = TransferAct { proofs: [proof1, proof2] }
+  let redeemer = TransferAct { params_idx: 0, proofs: [proof1, proof2] }
 
   when redeemer is {
-    TransferAct { proofs } -> list.length(proofs) == 2
+    TransferAct { proofs, .. } -> list.length(proofs) == 2
     _ -> False
   }
 }
@@ -353,7 +353,11 @@ fn validate_third_party_with_outputs(
     ],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -477,7 +481,11 @@ test third_party_act_seized_tokens_escape_prog_cred_must_fail() fail {
     ],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -529,7 +537,7 @@ fn valid_seize_tx() -> Transaction {
 fn run_seize_tx(tx: Transaction) -> Bool {
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
-    ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 },
+    ThirdPartyAct { params_idx: 0, registry_node_idx: 1, outputs_start_idx: 0 },
     fixture.credential_validator_logic_global,
     tx,
   )
@@ -631,7 +639,11 @@ test third_party_act_partial_seizure_succeeds() {
     ],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -676,7 +688,11 @@ test third_party_act_delta_insufficient_remaining_fails() fail {
     ],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -730,7 +746,10 @@ test transfer_act_partial_burn_with_mint_proofs_succeeds() {
     ],
   }
 
-  let redeemer = TransferAct { proofs: [TokenExists { node_idx: 1 }] }
+  let redeemer = TransferAct {
+    params_idx: 0,
+    proofs: [TokenExists { node_idx: 1 }],
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -774,7 +793,10 @@ test transfer_act_with_minting_succeeds() {
     ],
   }
 
-  let redeemer = TransferAct { proofs: [TokenExists { node_idx: 1 }] }
+  let redeemer = TransferAct {
+    params_idx: 0,
+    proofs: [TokenExists { node_idx: 1 }],
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -830,7 +852,10 @@ test transfer_act_transfer_plus_independent_pure_mint_succeeds() {
   }
 
   // No proof for idx 2, necessary for the mint but tx.mint is non-empty — must be rejected
-  let redeemer = TransferAct { proofs: [TokenExists { node_idx: 1 }] }
+  let redeemer = TransferAct {
+    params_idx: 0,
+    proofs: [TokenExists { node_idx: 1 }],
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -872,7 +897,7 @@ test transfer_act_with_only_minting_succeeds() {
   }
 
   // Finding 02 fix: pure mint requires NO TransferAct proof.
-  let redeemer = TransferAct { proofs: [] }
+  let redeemer = TransferAct { params_idx: 0, proofs: [] }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -917,7 +942,10 @@ test transfer_act_pure_mint_with_unnecessary_proof_must_fail() fail {
   }
 
   // ONE delta vs the success case above — surplus proof for the pure-mint policy.
-  let redeemer = TransferAct { proofs: [TokenExists { node_idx: 1 }] }
+  let redeemer = TransferAct {
+    params_idx: 0,
+    proofs: [TokenExists { node_idx: 1 }],
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -951,7 +979,7 @@ test transfer_act_pure_mint_without_transfer_logic_succeeds() {
     withdrawals: [Pair(fixture.credential_validator_logic_global, 0)],
   }
 
-  let redeemer = TransferAct { proofs: [] }
+  let redeemer = TransferAct { params_idx: 0, proofs: [] }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -989,7 +1017,10 @@ test transfer_act_burning_compensate_spending() {
     ],
   }
 
-  let redeemer = TransferAct { proofs: [TokenExists { node_idx: 1 }] }
+  let redeemer = TransferAct {
+    params_idx: 0,
+    proofs: [TokenExists { node_idx: 1 }],
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1031,7 +1062,10 @@ test transfer_act_entirely_burning_one_token() {
     ],
   }
 
-  let redeemer = TransferAct { proofs: [TokenExists { node_idx: 1 }] }
+  let redeemer = TransferAct {
+    params_idx: 0,
+    proofs: [TokenExists { node_idx: 1 }],
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1069,7 +1103,10 @@ test transfer_act_entirely_burning_one_token_fail_if_other_missing() fail {
     ],
   }
 
-  let redeemer = TransferAct { proofs: [TokenExists { node_idx: 1 }] }
+  let redeemer = TransferAct {
+    params_idx: 0,
+    proofs: [TokenExists { node_idx: 1 }],
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1106,7 +1143,10 @@ test transfer_act_unauthorized_burning_compensate_spending_fails() fail {
     withdrawals: [Pair(fixture.credential_validator_logic_global, 0)],
   }
 
-  let redeemer = TransferAct { proofs: [TokenExists { node_idx: 1 }] }
+  let redeemer = TransferAct {
+    params_idx: 0,
+    proofs: [TokenExists { node_idx: 1 }],
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1141,7 +1181,7 @@ test transfer_act_burning_compensate_spending_unproven_token_fails() fail {
     ],
   }
 
-  let redeemer = TransferAct { proofs: [] }
+  let redeemer = TransferAct { params_idx: 0, proofs: [] }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1192,7 +1232,11 @@ test third_party_act_wipe_full_burn_succeeds() {
     ],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1238,7 +1282,11 @@ test third_party_act_wipe_partial_burn_succeeds() {
     ],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1287,7 +1335,11 @@ test third_party_act_wipe_seize_and_partial_burn() {
     ],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1333,7 +1385,11 @@ test third_party_act_wipe_insufficient_after_burn_fails() fail {
     ],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1372,7 +1428,11 @@ test third_party_act_unauthorized_burn_compensate_spend() fail {
     withdrawals: [Pair(fixture.credential_validator_logic_global, 0)],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1414,7 +1474,11 @@ test third_party_act_unproven_burn_compensate_spend() fail {
     ],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1483,7 +1547,11 @@ test third_party_act_same_policy_mint_during_seizure_succeeds() {
     ],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1529,7 +1597,11 @@ test third_party_act_same_policy_mint_insufficient_output_fails() fail {
     ],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1579,7 +1651,11 @@ test third_party_act_unrelated_policy_mint_succeeds() {
     ],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1628,7 +1704,11 @@ test third_party_act_wipe_burn_plus_unrelated_mint_succeeds() {
     ],
   }
 
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx: 0 }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx: 0,
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1673,7 +1753,10 @@ test transfer_act_mint_insufficient_output_fails() fail {
     ],
   }
 
-  let redeemer = TransferAct { proofs: [TokenExists { node_idx: 1 }] }
+  let redeemer = TransferAct {
+    params_idx: 0,
+    proofs: [TokenExists { node_idx: 1 }],
+  }
 
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
@@ -1756,7 +1839,11 @@ fn validate_third_party_with_inputs_and_outputs(
       Pair(test_third_party_cred, 0),
     ],
   }
-  let redeemer = ThirdPartyAct { registry_node_idx: 1, outputs_start_idx }
+  let redeemer = ThirdPartyAct {
+    params_idx: 0,
+    registry_node_idx: 1,
+    outputs_start_idx,
+  }
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
     redeemer,
@@ -2026,7 +2113,7 @@ fn cov_absence(node_key: ByteArray, node_next: ByteArray) -> Bool {
   }
   programmable_logic_global.programmable_logic_global.withdraw(
     fixture.policy_protocol_params,
-    TransferAct { proofs: [TokenDoesNotExist { node_idx: 1 }] },
+    TransferAct { params_idx: 0, proofs: [TokenDoesNotExist { node_idx: 1 }] },
     fixture.credential_validator_logic_global,
     tx,
   )

--- a/validators/unfracking.ak
+++ b/validators/unfracking.ak
@@ -63,7 +63,8 @@ validator unfracking(params_policy: PolicyId) {
   ) {
     trace @"Starting unfracking validation"
 
-    let UnfrackingRedeemer { registry_node_idx, outputs_start_idx } = redeemer
+    let UnfrackingRedeemer { params_idx, registry_node_idx, outputs_start_idx }
+      = redeemer
 
     // Extract protocol parameters from reference inputs: the registry
     // NFT policy (field 0) to authenticate the acted-on policy's node,
@@ -72,6 +73,7 @@ validator unfracking(params_policy: PolicyId) {
     let fields <- with_protocol_params_fields(
       self.reference_inputs,
       params_policy,
+      params_idx,
     )
 
     let registry_node = locate_registry_node(


### PR DESCRIPTION
## What / Why

Fixes #103 (Finding 082). Supersedes this PR's original scan-based fix with a
uniform **redeemer-supplied index** for locating the protocol-params UTxO.

Every validator that reads the protocol-params UTxO previously **scanned** the
transaction's reference inputs looking for the params policy. That scan was:

- **O(position)** — a programmable-token tx references several scripts, each a
  reference input, so the params UTxO is rarely first; and
- **brittle**: the old `peek_first` scan *aborted* on a token-less
  (Ada-only) reference-script UTxO ordered ahead of the params NFT — Finding
  082 — a failure decided by `(tx_hash, index)` ordering the builder cannot
  control.

This PR replaces the scan with `list.at(reference_inputs, params_idx)` +
**NFT authentication** (the one-shot params NFT must be present on the addressed
input). That is O(1) per lookup, and makes 082 *structurally impossible*: an
input the caller does not address is never inspected.

Because `programmable_logic_base` runs **once per spent input**, the saving
multiplies across a multi-input transaction — which is exactly why the same
scheme is applied uniformly rather than only where 082 bit.

### Benchmark
The index wins whenever the params UTxO is **not** the first reference input
(i.e. almost always), by ~2.3M cpu / ~6k mem **per position** it would otherwise
have had to scan past. On PLB this is per-input.

## Breaking redeemer surface (pre-mint, upgradability branch)

| Validator | Before | After |
|---|---|---|
| `programmable_logic_base.spend` | ignored `Data` | `Int` (params index) |
| `ProgrammableLogicGlobalRedeemer` | `TransferAct{proofs}` / `ThirdPartyAct{..}` / `UnfrackingAct` | each variant gains a leading `params_idx: Int` |
| `UnfrackingRedeemer` | `{registry_node_idx, outputs_start_idx}` | leading `params_idx: Int` added |
| `params.with_protocol_params_fields` | scanned | takes `params_idx`; scan removed |

`issuance_mint` intentionally keeps its NFT-membership `list.find` (fail-safe:
absent coordination UTxO ⇒ local custody), which an *aborting* index would
break — so it takes **no** index. Documented inline.

### Authentication argument
`params_idx` is attacker-controlled, but the params policy is a **one-shot NFT**
minted once at bootstrap; an attacker cannot forge it. Pointing the index at any
other input simply fails the `!dict.is_empty(tokens(_, params_cs))` check. No new
attack surface.

## Off-chain follow-up (out of scope here)
Builders must compute the params UTxO's position in the **canonical**
`reference_inputs` ordering (sorted by `(tx_id, output_index)`) and pass it in
each redeemer. **cip113-sdk-ts** and the **Java backend** need corresponding
updates — tracked separately.

## Docs
- `02-ARCHITECTURE.md`, `08-INTEGRATION-GUIDES.md`, `09-DEVELOPING-SUBSTANDARDS.md`
- Migration section **§16** in `cip113-api-changes-post-audit.md`

## Tests
Full suite green (2635 checks, 0 failures). Includes `params_idx != 0` coverage
(`plb_passes_when_params_ref_not_first`, index-past-Ada-only-refscript lookup)
and the 082 regression converted to the index model.

Fixes #103 
