### PR TITLE
fix: constrain PLB output shape at creation (issue #106)

### DIFF
--- a/lib/assets.ak
+++ b/lib/assets.ak
@@ -6,6 +6,7 @@ use cardano/transaction.{Output}
 use env
 use list
 use tokens.{Tokens}
+use utils
 
 pub type Assets =
   Pairs<PolicyId, Tokens>
@@ -184,6 +185,13 @@ pub fn has_policy_nft_strictly(
   actual_asset_name == asset_name
 }
 
+/// Collect the assets of every output at the programmable-logic base
+/// credential. Every selected output must carry an inline stake credential
+/// (so ownership is well-defined) and a seizable shape (issue #106): datum
+/// absent or inline — never a hash — and no reference script. Constraining
+/// the shape HERE, at the creation site, is what keeps `ThirdPartyAct`'s
+/// byte-for-byte reproduction satisfiable for the issuer; see
+/// `utils.is_seizable_shape`.
 pub fn collect_output_assets(
   outputs: List<Output>,
   prog_logic_cred: Credential,
@@ -194,6 +202,7 @@ pub fn collect_output_assets(
     fn(output, select, discard) {
       if output.address.payment_credential == prog_logic_cred {
         expect Some(Inline(..)) = output.address.stake_credential
+        expect utils.is_seizable_shape(output)?
         select(output)
       } else {
         discard()

--- a/lib/utils.ak
+++ b/lib/utils.ak
@@ -5,7 +5,35 @@ use aiken/builtin.{tail_list}
 use aiken/collection/dict
 use cardano/address.{Credential, Script}
 use cardano/assets.{PolicyId, Value}
-use cardano/transaction.{InlineDatum, Output}
+use cardano/transaction.{DatumHash, InlineDatum, NoDatum, Output}
+
+/// A programmable-token (PLB) output has a *seizable shape* iff its datum
+/// is absent or inline — never a hash — and it carries no reference script.
+///
+/// Both constraints exist for the same reason (issue #106): seizure
+/// (`ThirdPartyAct`) and unfracking must reproduce `address`, `datum` and
+/// `reference_script` byte-for-byte on the paired continuing output, so any
+/// shape only the holder can reproduce (or afford) defeats them while
+/// `TransferAct` keeps working:
+///
+///   * `DatumHash`: the ledger (phase 1) demands the datum preimage in the
+///     witness set of any transaction SPENDING the output. The holder keeps
+///     the secret, so the issuer cannot even form the seizure transaction.
+///   * reference script: the continuing output must embed the full script
+///     bytes, so a large script pushes every seizure over `maxTxSize`.
+///
+/// Enforced at every PLB-output creation site (`assets.collect_output_assets`,
+/// `issuance_mint`'s `no_escape`, the unfracking destination); the
+/// reproduction sites then preserve it by induction, so no live PLB UTxO can
+/// ever take an unseizable shape.
+pub fn is_seizable_shape(output: Output) -> Bool {
+  let datum_admissible = when output.datum is {
+    NoDatum -> True
+    DatumHash(_) -> False
+    InlineDatum(_) -> True
+  }
+  datum_admissible && output.reference_script == None
+}
 
 /// Get the datum from an output, expecting an inline datum
 pub fn expect_inline_datum(output: Output) -> Data {

--- a/lib/utils.test.ak
+++ b/lib/utils.test.ak
@@ -2,11 +2,60 @@
 
 use aiken/collection/dict
 use aiken/collection/list
+use cardano/address.{Address, Script}
 use cardano/assets.{
   PolicyId, Value, ada_asset_name, ada_policy_id, add, from_asset, zero,
 }
+use cardano/transaction.{DatumHash, InlineDatum, NoDatum, Output}
 use utils.{
-  bytearray_lt, count_unique_tokens, has_currency_symbol, mint_has_policy,
+  bytearray_lt, count_unique_tokens, has_currency_symbol, is_seizable_shape,
+  mint_has_policy,
+}
+
+/// A well-shaped PLB-like output: no datum, no reference script.
+const some_plb_shaped_output: Output =
+  Output {
+    address: Address {
+      payment_credential: Script(
+        #"0000000000000000000000000000000000000000000000000000ba5e",
+      ),
+      stake_credential: None,
+    },
+    value: from_asset(ada_policy_id, ada_asset_name, 1_000_000),
+    datum: NoDatum,
+    reference_script: None,
+  }
+
+test is_seizable_shape_accepts_no_datum() {
+  is_seizable_shape(some_plb_shaped_output)
+}
+
+test is_seizable_shape_accepts_inline_datum() {
+  is_seizable_shape(
+    Output { ..some_plb_shaped_output, datum: InlineDatum(as_data(0)) },
+  )
+}
+
+test is_seizable_shape_rejects_datum_hash() {
+  !is_seizable_shape(
+    Output {
+      ..some_plb_shaped_output,
+      datum: DatumHash(
+        #"c0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffee0000",
+      ),
+    },
+  )
+}
+
+test is_seizable_shape_rejects_reference_script() {
+  !is_seizable_shape(
+    Output {
+      ..some_plb_shaped_output,
+      reference_script: Some(
+        #"00000000000000000000000000000000000000000000000000000abe",
+      ),
+    },
+  )
 }
 
 // Test bytearray_lt with different bytearrays

--- a/validators/issuance_mint.ak
+++ b/validators/issuance_mint.ak
@@ -140,7 +140,9 @@ validator issuance_mint(
 /// output total to the mint delta and could be satisfied by preserved supply).
 ///
 /// Every PLB output must additionally carry an inline stake credential (so
-/// ownership is well-defined). Inputs need no scan: any `own_policy` spent
+/// ownership is well-defined) and a seizable shape — datum absent or inline,
+/// never a hash, and no reference script (issue #106; see
+/// `utils.is_seizable_shape`). Inputs need no scan: any `own_policy` spent
 /// must reappear at a PLB output or be burned, both of which this output-only
 /// rule already forces through value-conservation.
 ///
@@ -156,7 +158,11 @@ fn no_escape(
     fn(output) {
       if output.address.payment_credential == programmable_logic_base {
         expect Some(Inline(_stake_cred)) = output.address.stake_credential
-        True
+        // Issue #106: a freshly minted PLB output must also be seizable by
+        // shape — datum absent or inline (never a hash), no reference
+        // script — or `ThirdPartyAct`'s byte-for-byte reproduction becomes
+        // unsatisfiable for the issuer from the moment of issuance.
+        utils.is_seizable_shape(output)?
       } else {
         dict.is_empty(assets.tokens(output.value, own_policy))
       }

--- a/validators/issuance_mint.test.ak
+++ b/validators/issuance_mint.test.ak
@@ -10,8 +10,8 @@
 use cardano/address.{Address, Credential, Inline, Script}
 use cardano/assets.{PolicyId, ada_asset_name, ada_policy_id, from_asset}
 use cardano/transaction.{
-  InlineDatum, Input, Mint, NoDatum, Output, OutputReference, Transaction,
-  Withdraw,
+  DatumHash, InlineDatum, Input, Mint, NoDatum, Output, OutputReference,
+  Transaction, Withdraw,
 }
 use issuance_mint
 use programmable_logic/params.{ProgrammableLogicGlobalParams}
@@ -1508,4 +1508,34 @@ test outputindex_covering_node_mint_escape_fails() fail {
     redeemers: [Pair(Mint(test_own_policy), as_data(rdmr))],
   }
   call_validator(rdmr, tx)
+}
+
+// ========================================================================
+// Issue #106 — PLB output shape at the mint creation site (`no_escape`)
+// ========================================================================
+
+// Minted tokens sent to a PLB output carrying a datum HASH — must fail:
+// only the preimage holder could ever spend (so seize) that output.
+test mint_output_datum_hash_fails() fail {
+  let bad_output = Output {
+    ..mint_output(100),
+    datum: DatumHash(
+      #"c0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffee0000",
+    ),
+  }
+  let tx = Transaction { ..valid_mint_tx(), outputs: [bad_output] }
+  call_validator(valid_redeemer(), tx)
+}
+
+// Minted tokens sent to a PLB output carrying a reference script — must
+// fail: seizure would have to reproduce the script bytes forever after.
+test mint_output_reference_script_fails() fail {
+  let bad_output = Output {
+    ..mint_output(100),
+    reference_script: Some(
+      #"00000000000000000000000000000000000000000000000000000abe",
+    ),
+  }
+  let tx = Transaction { ..valid_mint_tx(), outputs: [bad_output] }
+  call_validator(valid_redeemer(), tx)
 }

--- a/validators/programmable_logic/unfracking.ak
+++ b/validators/programmable_logic/unfracking.ak
@@ -88,6 +88,7 @@ use pairs
 use programmable_logic/owner.{authorised_stake_cred}
 use registry_node.{with_key_and_unfracking_logic}
 use tokens.{Tokens}
+use utils
 
 /// Validate an Unfracking action. See module docstring for the full
 /// invariant list. `registry_node` is the acted-on policy's registry
@@ -241,6 +242,11 @@ fn validate_pairs_and_conservation(
         output_tokens,
         fn(output, acc) {
           if output.address == owner_address {
+            // Issue #106: destination outputs are CREATED here (unlike the
+            // paired continuing outputs, which reproduce their input
+            // byte-for-byte), so the PLB shape rule binds at this site too:
+            // datum absent or inline (never a hash), no reference script.
+            expect utils.is_seizable_shape(output)?
             tokens.union(output.value |> value.tokens(policy_id), acc)
           } else {
             acc

--- a/validators/programmable_logic/unfracking.test.ak
+++ b/validators/programmable_logic/unfracking.test.ak
@@ -23,7 +23,7 @@ use cardano/address.{Credential, VerificationKey}
 use cardano/assets.{
   AssetName, PolicyId, ada_asset_name, ada_policy_id, from_asset, merge,
 }
-use cardano/transaction.{InlineDatum, Input, Output, Transaction}
+use cardano/transaction.{DatumHash, InlineDatum, Input, Output, Transaction}
 use programmable_logic/fixture
 use programmable_logic/params.{ProgrammableLogicGlobalParams}
 use programmable_logic_base
@@ -818,4 +818,47 @@ test unfracking_full_composition_succeeds() {
     run_plg_unfracking_gate(tx),
     run_unfracking(tx),
   }
+}
+
+// Destination outputs are CREATED by the unfracking transaction (unlike the
+// paired continuing outputs, which reproduce their input byte-for-byte), so
+// the PLB shape rule (issue #106) binds here. ONE delta: the extra output's
+// datum becomes a hash.
+test unfracking_fails_destination_datum_hash() fail {
+  let tx = valid_unfracking_tx()
+  expect [pair_out, extra] = tx.outputs
+  run_unfracking(
+    Transaction {
+      ..tx,
+      outputs: [
+        pair_out,
+        Output {
+          ..extra,
+          datum: DatumHash(
+            #"c0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffeec0ffee0000",
+          ),
+        },
+      ],
+    },
+  )
+}
+
+// Same site, ONE delta: the extra output carries a reference script.
+test unfracking_fails_destination_reference_script() fail {
+  let tx = valid_unfracking_tx()
+  expect [pair_out, extra] = tx.outputs
+  run_unfracking(
+    Transaction {
+      ..tx,
+      outputs: [
+        pair_out,
+        Output {
+          ..extra,
+          reference_script: Some(
+            #"00000000000000000000000000000000000000000000000000000abe",
+          ),
+        },
+      ],
+    },
+  )
 }

--- a/validators/programmable_logic_global.test.ak
+++ b/validators/programmable_logic_global.test.ak
@@ -8,7 +8,7 @@ use cardano/assets.{
   zero,
 }
 use cardano/transaction.{
-  InlineDatum, Input, NoDatum, Output, OutputReference, Transaction,
+  DatumHash, InlineDatum, Input, NoDatum, Output, OutputReference, Transaction,
 }
 use programmable_logic/fixture
 use programmable_logic/params.{ProgrammableLogicGlobalParams}
@@ -2143,5 +2143,65 @@ test fails_absence_proof_when_node_ends_below_policy() fail {
   cov_absence(
     #"11111111111111111111111111111111111111111111111111111111",
     #"22222222222222222222222222222222222222222222222222222222",
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Issue #106 — PLB output shape at the TransferAct creation site
+//
+// A holder must not be able to route programmable tokens into a PLB output
+// whose shape defeats seizure while leaving their own spending intact:
+//
+//   * `DatumHash` datum — the ledger (phase 1) demands the datum preimage in
+//     the witness set of any SPENDING transaction. The holder keeps the
+//     secret, so the issuer cannot even form the seizure transaction.
+//   * reference script — `ThirdPartyAct` must reproduce the full script
+//     bytes on the paired continuing output, so a large script pushes every
+//     seizure over `maxTxSize`; `TransferAct` spends unaffected.
+//
+// One delta per failure test: the happy-path fixture output with exactly one
+// field overridden.
+// ---------------------------------------------------------------------------
+
+/// Run a canonical single-policy TransferAct whose sole PLB output is the
+/// given one. The fixture's own output (same tokens, `NoDatum`, no
+/// reference script) is the green control.
+fn run_transfer_with_output(output: Output) -> Bool {
+  let (tx, redeemer) = fixture.some_transfer([(test_token_cs, "FOO", 100)])
+  let tx = Transaction { ..tx, outputs: [output] }
+  programmable_logic_global.programmable_logic_global.withdraw(
+    fixture.policy_protocol_params,
+    redeemer,
+    fixture.credential_validator_logic_global,
+    tx,
+  )
+}
+
+test transfer_act_shape_control_succeeds() {
+  run_transfer_with_output(
+    fixture.some_output_with_programmable_tokens([(test_token_cs, "FOO", 100)]),
+  )
+}
+
+test transfer_act_fails_datum_hash_output() fail {
+  let base = fixture.some_output_with_programmable_tokens(
+    [(test_token_cs, "FOO", 100)],
+  )
+  run_transfer_with_output(
+    Output { ..base, datum: DatumHash(blake2b_256("holder secret")) },
+  )
+}
+
+test transfer_act_fails_reference_script_output() fail {
+  let base = fixture.some_output_with_programmable_tokens(
+    [(test_token_cs, "FOO", 100)],
+  )
+  run_transfer_with_output(
+    Output {
+      ..base,
+      reference_script: Some(
+        #"00000000000000000000000000000000000000000000000000000abe",
+      ),
+    },
   )
 }


### PR DESCRIPTION
Fixes #106.

## Summary

A holder can shape their own PLB UTxOs (datum hash, reference script) so that issuer seizure (`ThirdPartyAct`) becomes impossible to construct while the holder keeps spending via `TransferAct`. This PR closes vectors 1 and 2 of #106 the way the issue proposes: constrain the output shape at every PLB-output **creation** site, and leave the seizure/unfracking byte-for-byte **reproduction** checks strict (relaxing them would let a co-resident policy's admin tamper with a victim's datum).

## Fix

New total predicate `utils.is_seizable_shape(output)`:

- datum is `NoDatum` or `InlineDatum(_)` — never `DatumHash(_)`. Spending a datum-hash output requires the preimage in the witness set (ledger phase 1), which only the holder has, so the issuer cannot even form the seizure transaction.
- `reference_script == None`. Seizure must reproduce the full script bytes on the paired continuing output, so a large script pushes every seizure over `maxTxSize` while `TransferAct` spends unaffected.

Enforced at the three creation sites named in the issue:

1. `lib/assets.ak` `collect_output_assets` — the `TransferAct` output scan.
2. `validators/issuance_mint.ak` `no_escape` — mint-side PLB outputs.
3. `validators/programmable_logic/unfracking.ak` — the destination fold (unpaired outputs at the owner address). The paired continuing outputs reproduce their inputs byte-for-byte, so they inherit the shape by induction.

The standard is not deployed, so this is genesis enforcement with no migration.

## Not in this PR (follow-ups)

- **Vector 3 (inline-datum size bound):** the issue flags the bound `N` as an open design decision (and whether PLB UTxOs should carry inline datums at all). Deliberately left out; happy to follow up once the bound is decided.
- **`ThirdPartyAct` destination outputs:** the unpaired outputs receiving seized tokens are created by the seizing issuer, so a bad shape there only harms the actor that chose it; the issue scopes them out. Worth a follow-up decision if you want the "no PLB UTxO ever has an unseizable shape" invariant to be unconditional.
- `plutus.json` is left to the usual `chore: latest plutus json` regeneration.

## Testing

Red-first: the six repro tests were written and run **before** the fix — all six failed (the validators accept holder-shaped outputs today), with a green shape control on the happy path. After the fix the full suite is green: **369 passed, 0 failed** (`aiken check`, v1.1.23), `aiken fmt --check` clean.

- `transfer_act_fails_datum_hash_output` / `transfer_act_fails_reference_script_output` (+ `transfer_act_shape_control_succeeds` control) — end-to-end `TransferAct` through `programmable_logic_global.withdraw`.
- `mint_output_datum_hash_fails` / `mint_output_reference_script_fails` — `no_escape` path.
- `unfracking_fails_destination_datum_hash` / `unfracking_fails_destination_reference_script` — unfracking destination, one delta per test off the shared fixture.
- Four unit tests pin `is_seizable_shape` itself (both accepts, both rejects).
