### PR TITLE
chore(toolchain) bump Aiken to v1.1.23; refresh the two cost records

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: aiken-lang/setup-aiken@v1
         with:
-          version: v1.1.22
+          version: v1.1.23
       - run: aiken fmt --check
       - run: aiken check -D
       # The assertions env compiles env/with_assertions.ak in place of the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CIP-113 Programmable Tokens — Aiken Implementation
 
-![Aiken](https://img.shields.io/badge/Aiken-v1.1.22-blue)
+![Aiken](https://img.shields.io/badge/Aiken-v1.1.23-blue)
 ![CIP-113](https://img.shields.io/badge/CIP--113-Last%20Check-green)
 ![Status](https://img.shields.io/badge/Status-Audit%20in%20progress-yellow)
 
@@ -66,7 +66,7 @@ Programmable tokens are **native Cardano assets** with an additional layer of va
 
 ### Prerequisites
 
-- [Aiken](https://aiken-lang.org/installation-instructions) v1.1.22 (pinned in `aiken.toml`)
+- [Aiken](https://aiken-lang.org/installation-instructions) v1.1.23 (pinned in `aiken.toml`)
 - [Cardano CLI](https://github.com/IntersectMBO/cardano-cli) (optional, for deployment)
 
 ### Build

--- a/aiken.toml
+++ b/aiken.toml
@@ -1,6 +1,6 @@
 name = "cardano-foundation/cip113-programmable-tokens"
-version = "0.5.0-alpha.1"
-compiler = "v1.1.22"
+version = "0.5.0-alpha.2"
+compiler = "v1.1.23"
 plutus = "v3"
 license = "Apache-2.0"
 description = "Aiken implementation of CIP-113 programmable tokens"

--- a/plutus.json
+++ b/plutus.json
@@ -2,11 +2,11 @@
   "preamble": {
     "title": "cardano-foundation/cip113-programmable-tokens",
     "description": "Aiken implementation of CIP-113 programmable tokens",
-    "version": "0.5.0-alpha.1",
+    "version": "0.5.0-alpha.2",
     "plutusVersion": "v3",
     "compiler": {
       "name": "Aiken",
-      "version": "v1.1.22+39d6b04"
+      "version": "v1.1.23+8949565"
     },
     "license": "Apache-2.0"
   },

--- a/validators/programmable_logic/params_cost.test.ak
+++ b/validators/programmable_logic/params_cost.test.ak
@@ -18,18 +18,19 @@
 //// `registry_node_cs` (0), `prog_logic_cred` (1), then the two credentials
 //// programmable_logic_base reads on its per-input dispatch — `transfer_cred`
 //// (2) and `third_party_cred` (3) — then `unfracking_cred` (4, read by the transfer validator's
-//// unfracking action) and `upgrade_cred` (5, read only by `coordination_spend`
-//// on an upgrade). The 2- and 3-field shapes are kept as local types so
+//// unfracking action), `upgrade_cred` (5, read only by `coordination_spend`
+//// on an upgrade) and `max_inline_datum_bytes` (6, issue #106 vector 3, read
+//// once per delegate invocation). The 2- and 3-field shapes are kept as local types so
 //// their measurements stay reproducible after the production type moved on.
 ////
-//// Representative run (aiken v1.1.22; ABSOLUTE mem/cpu per test — compare
+//// Representative run (aiken v1.1.23; ABSOLUTE mem/cpu per test — compare
 //// rows, they share one reference-input layout. Since the #103 index change
 //// the split path locates the params UTxO by index while the baseline scans,
 //// so subtracting the baseline no longer isolates pure extraction cost; read
 //// the rows against each other instead):
 ////
-////   locate + unwrap baseline (6-field) ......... 459.8k mem / 147.2M cpu
-////   (b) 6-field full expect .................... 530.2k mem / 169.4M cpu
+////   locate + unwrap baseline (7-field) ......... 459.8k mem / 147.4M cpu
+////   (b) 7-field full expect .................... 533.6k mem / 170.3M cpu
 ////   (c) split, fields 0-1 (shared shallow) ..... 486.3k mem / 153.1M cpu
 ////   (c) split, transfer_cred field 2 (PLB) ..... 483.2k mem / 152.4M cpu
 ////   (c) split, unfracking_cred field 4 ......... 483.6k mem / 152.6M cpu
@@ -38,9 +39,9 @@
 //// (Legacy 2-/3-field full-expect rows, kept for reproducibility: 488.5k/
 //// 154.9M and 503.0k/160.4M — validating more fields costs strictly more.)
 ////
-//// i.e. the transfer hot path (fields 0-1) pays ~+5.9M cpu / +26.6k mem over the
-//// bare locate+unwrap, versus ~+22.0M cpu / +70.2k mem to `expect` the whole
-//// 6-field record — the split saves the hot path from validating four fields
+//// i.e. the transfer hot path (fields 0-1) pays ~+5.7M cpu / +26.5k mem over the
+//// bare locate+unwrap, versus ~+22.9M cpu / +73.8k mem to `expect` the whole
+//// 7-field record — the split saves the hot path from validating five fields
 //// it never reads. Skipping whole-record validation is safe because
 //// protocol_params_mint fully deserialises the datum at mint time (see
 //// `with_protocol_params_fields` docs).

--- a/validators/programmable_logic/wdrl_idx_cost.test.ak
+++ b/validators/programmable_logic/wdrl_idx_cost.test.ak
@@ -15,27 +15,27 @@
 //// local reproduction of the pre-split scan over the same params read, so
 //// the two columns share every cost except the lookup itself.
 ////
-//// Representative run (aiken v1.1.22; mem / cpu per test, ABSOLUTE):
+//// Representative run (aiken v1.1.23; mem / cpu per test, ABSOLUTE):
 ////
 ////   width  position   indexed (PLB as shipped)     scan (pre-split check)
 ////   -----  --------   ------------------------     ----------------------
-////     1       0      299.7k /  94.17M            286.7k /  90.00M
-////     4       0      322.1k / 104.00M            309.1k /  99.83M
-////     4       3      334.8k / 107.87M            323.0k / 107.88M
-////     8       0      351.9k / 117.12M            338.9k / 112.95M
-////     8       4      366.4k / 121.58M            357.4k / 123.68M
-////     8       7      379.1k / 125.44M            371.3k / 131.73M
-////    16       0      411.6k / 143.35M            398.6k / 139.18M
-////    16      15      467.7k / 160.59M            468.0k / 179.42M
+////     1       0      297.9k /  93.07M            286.7k /  90.00M
+////     4       0      320.3k / 102.91M            309.1k /  99.83M
+////     4       3      333.0k / 106.78M            323.0k / 107.88M
+////     8       0      350.2k / 116.02M            338.9k / 112.95M
+////     8       4      364.6k / 120.48M            357.4k / 123.68M
+////     8       7      377.3k / 124.35M            371.3k / 131.73M
+////    16       0      409.8k / 142.25M            398.6k / 139.18M
+////    16      15      465.9k / 159.50M            468.0k / 179.42M
 ////
 //// (Absolute figures include building the fixture transaction, which is why
 //// both columns grow with width; compare rows, not totals.)
 ////
-//// Per position, the indexed path grows ~1.1M cpu (one cell drop) and the
+//// Per position, the indexed path grows ~1.2M cpu (one cell drop) and the
 //// scan ~2.7M cpu (cell drop + credential comparison). The indexed path pays
-//// a fixed ~4.2M cpu at position 0 for decoding its redeemer and the 2-arm
-//// dispatch, so the two cross at position ~3; by width 16 / position 15 the
-//// witness saves ~19M cpu and the memory difference has vanished.
+//// a fixed ~3.1M cpu at position 0 for decoding its redeemer and the 3-arm
+//// dispatch, so the two cross at position ~2; by width 16 / position 15 the
+//// witness saves ~20M cpu and the memory difference has vanished.
 ////
 //// Read the indexed column down a width: cost rises with `position`, which
 //// is the O(`wdrl_idx`) growth. Read across a row: the gap to the scan is


### PR DESCRIPTION
`aiken.toml` moves to compiler v1.1.23 (and 0.5.0-alpha.2). Everything that pinned the old version follows: the CI workflow's `setup-aiken` input, the README badge and prerequisite line, and the `plutus.json` preamble.

The bump is byte-neutral on chain. Rebuilding under v1.1.23 produces IDENTICAL `compiledCode` and script hashes for all 27 blueprint entries, so there is no hash cascade and no redeploy — `plutus.json` changes only in its preamble (version + compiler strings). Verified by diffing the committed v1.1.22 blueprint against a fresh v1.1.23 build.

All four CI steps pass on v1.1.23: `aiken fmt --check`, `aiken check -D` 477/477, `aiken check -D --env with_assertions` 477/477, `aiken build`.

Also refreshes the two cost records, which had drifted for reasons unrelated to the compiler:

  * `wdrl_idx_cost` — the `indexed` column was stale by ~1.1M cpu, exactly the PLB saving from #114; the `scan` column (a local reproduction that never calls PLB) was unaffected, which is what isolates the cause. The derived analysis moves with it: the fixed position-0 cost drops 4.2M -> ~3.1M, so the crossover against the old scan moves from position ~3 to ~2, and the width-16/position-15 saving rises to ~20M cpu. Also corrects "2-arm dispatch" to 3-arm, stale since #110.
  * `params_cost` — the params record is seven fields since the `max_inline_datum_bytes` addition, so the "6-field full expect" row and its two derived deltas were understating the whole-record cost (169.4M -> 170.3M; +22.0M -> +22.9M over the bare locate+unwrap). The field-order note gains field 6.

Both records now carry the v1.1.23 attribution they were measured under.