### PR TITLE
Defend the nomination authority rail and repair two governance fixtures

### DIFF
--- a/validators/protocol_params_upgrade.test.ak
+++ b/validators/protocol_params_upgrade.test.ak
@@ -341,11 +341,13 @@ test params_spend_fails_with_wrong_authority() fail {
   call(tx)
 }
 
-// An incoming credential cannot install itself under an ORDINARY upgrade: it
-// presents its own withdraw-0 and writes itself in as the authority, but
-// `ProtocolUpgrade` is authorised by the sitting credential and refuses to
-// move `upgrade_cred` at all. The same attempt declared as `PromoteAuthority`
-// is covered by `params_spend_fails_promotion_declared_without_nomination`.
+// An incoming credential cannot install itself under an ORDINARY upgrade.
+// The sitting authority's withdraw-0 IS present, so authorisation passes and
+// the only remaining delta is the `upgrade_cred` rewrite, which
+// `ProtocolUpgrade` refuses. Carrying only the incoming credential's
+// withdrawal would make this a two-delta test that no single rail decides.
+// The same attempt declared as `PromoteAuthority` is covered by
+// `params_spend_fails_promotion_declared_without_nomination`.
 test params_spend_fails_self_installation_under_ordinary_upgrade() fail {
   let tx = Transaction {
     ..valid_upgrade_tx(),
@@ -359,7 +361,7 @@ test params_spend_fails_self_installation_under_ordinary_upgrade() fail {
         params_spend_address(),
       ),
     ],
-    withdrawals: [Pair(new_transfer_cred, 0)],
+    withdrawals: [Pair(authority_cred, 0), Pair(new_transfer_cred, 0)],
   }
   call(tx)
 }
@@ -678,6 +680,33 @@ test params_spend_nomination_succeeds() {
       fixture.protocol_params,
       params_in_flight(),
       [Pair(authority_cred, 0)],
+    ),
+  )
+}
+
+// The sitting authority must approve a nomination. `NominateAuthority` reads
+// `sitting_authority_approves` from the OLD datum exactly as `ProtocolUpgrade`
+// does; without it, leg 2 needs only the nominee's own withdraw-0, so an
+// unapproved nomination followed by a promotion is a two-transaction,
+// permissionless seizure of `upgrade_cred`.
+test params_spend_fails_nomination_without_authority_withdrawal() fail {
+  call_from(
+    NominateAuthority,
+    fixture.protocol_params,
+    handover_tx(fixture.protocol_params, params_in_flight(), []),
+  )
+}
+
+// Some OTHER credential's withdraw-0 does not authorise a nomination either.
+// The twin of `params_spend_fails_with_wrong_authority` on the nomination arm.
+test params_spend_fails_nomination_with_wrong_authority() fail {
+  call_from(
+    NominateAuthority,
+    fixture.protocol_params,
+    handover_tx(
+      fixture.protocol_params,
+      params_in_flight(),
+      [Pair(new_transfer_cred, 0)],
     ),
   )
 }

--- a/validators/upgrade_multisig.test.ak
+++ b/validators/upgrade_multisig.test.ak
@@ -41,9 +41,13 @@ const mallory: ByteArray =
 const own_hash: ByteArray =
   #"5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e"
 
-/// A different withdraw-0 script, for the `Script` leaf.
+/// A different withdraw-0 script, for the `Script` leaf. Exactly 28 bytes:
+/// `shape_ok` rejects any other length, so a longer hash makes every tree
+/// built from this constant unwritable through `mint` or `spend`, and the
+/// tests below would pass only because `withdraw` does not re-check
+/// `well_formed`.
 const governance_hash: ByteArray =
-  #"6060606060606060606060606060606060606060606060606060606060"
+  #"60606060606060606060606060606060606060606060606060606060"
 
 const seed_ref: OutputReference =
   OutputReference {
@@ -578,6 +582,18 @@ test withdraw_honours_script_leaf() {
 test withdraw_fails_script_leaf_without_withdrawal() fail {
   let tree = multisig.Script { script_hash: governance_hash }
   call_withdraw(withdraw_tx(tree, [alice, bob, carol]))
+}
+
+// The `Script`-leaf tree the two tests above authorise against is one a real
+// deployment could install. `withdraw` never re-checks `well_formed`, so
+// without this control those tests would still pass if the constant were the
+// wrong length and no `spend` or `mint` could ever have written the tree.
+test update_installs_script_leaf_tree() {
+  let tree = multisig.Script { script_hash: governance_hash }
+  call_spend(
+    two_of_three(),
+    Transaction { ..update_tx(), outputs: [config_output(tree)] },
+  )
 }
 
 // `After` leaf: approve now, execute only once the validity range starts at or


### PR DESCRIPTION
Test-only fixes from the comment-versus-code triage. All 34 validators keep their exact `compiledCode` and `hash`; nothing needs redeploying.

**An authority rail no test defended.** `nominate_authority` reads `sitting_authority_approves` from the old datum, exactly as an ordinary upgrade does. Neutering that call left every one of the 605 tests green, because the existing guard covers the upgrade arm only. That matters because promotion needs nothing but the nominee's own withdraw-0, so if the rail were ever removed, an unapproved nomination followed by a promotion would seize the upgrade credential in two transactions, with no permission and with the suite still passing. Two guards are added, one delta each against the nomination happy path. Both pass against the real code and both fail when the call is neutered.

**A test that proved neither of its rails.** `params_spend_fails_self_installation_under_ordinary_upgrade` withheld the sitting authority's withdrawal *and* rewrote the upgrade credential. Each delta is caught by a different rail, so neither rail's mutant could kill it. It now carries the authority's withdrawal and rests on the frozen-field rail alone, which its comment always claimed.

**A fixture that could not exist.** The `Script`-leaf constant in the multisig suite was 29 bytes. Well-formedness requires 28, so neither the mint nor the spend handler could ever have written a tree built from it. The two tests using it passed only because the withdraw handler does not re-check well-formedness. The constant is corrected, and a positive control proves the tree is installable. That control fails against the old constant.

Verification: 608 tests pass under `aiken check -D` and under `--env with_assertions`; `aiken fmt --check` is clean; `aiken build` reproduces the committed blueprint; every validator's compiled code and hash is identical to main.

Still open, and not in this PR because it is a design decision: well-formedness bounds a multisig tree's shape but not the evidence a satisfying path requires, so an `AtLeast` count can be inflated by a single-child wrapper or by an already-satisfied time leaf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
